### PR TITLE
feat(agents): integrate Anyon agents into native agent system

### DIFF
--- a/src/agents/anyon-alpha/index.ts
+++ b/src/agents/anyon-alpha/index.ts
@@ -1,9 +1,15 @@
+import type { AgentConfig } from "@opencode-ai/sdk"
+import type { AgentMode, AgentPromptMetadata } from "../types"
+import { isGptModel } from "../types"
+import { createAgentToolRestrictions } from "../../shared/permission-compat"
 import { ANYON_ALPHA_IDENTITY_CONSTRAINTS } from "./identity-constraints"
 import { ANYON_ALPHA_INTERVIEW_MODE } from "./interview-mode"
 import { ANYON_ALPHA_DOCUMENT_GENERATION } from "./document-generation"
 import { ANYON_ALPHA_HIGH_ACCURACY_MODE } from "./high-accuracy-mode"
 import { ANYON_ALPHA_TEMPLATE } from "./template"
 import { ANYON_ALPHA_BEHAVIORAL_SUMMARY } from "./behavioral-summary"
+
+const MODE: AgentMode = "all"
 
 export const ANYON_ALPHA_SYSTEM_PROMPT = `${ANYON_ALPHA_IDENTITY_CONSTRAINTS}
 ${ANYON_ALPHA_INTERVIEW_MODE}
@@ -18,6 +24,52 @@ export const ANYON_ALPHA_PERMISSION = {
   webfetch: "allow" as const,
   question: "allow" as const,
 }
+
+export const ANYON_ALPHA_PROMPT_METADATA: AgentPromptMetadata = {
+  category: "specialist",
+  cost: "EXPENSIVE",
+  promptAlias: "Anyon Alpha",
+  triggers: [
+    { domain: "Product Planning", trigger: "PRD creation, idea refinement, requirement gathering" },
+  ],
+  useWhen: [
+    "User has vague product idea",
+    "Need to create PRD document",
+    "Non-technical founder needs planning help",
+  ],
+  avoidWhen: [
+    "Technical implementation or code writing",
+    "Already have clear, detailed requirements",
+    "Need UI/UX wireframes (use anyon-beta)",
+  ],
+}
+
+export function createAnyonAlphaAgent(model: string): AgentConfig {
+  const restrictions = createAgentToolRestrictions([
+    "call_omo_agent",
+  ])
+
+  const base = {
+    description: "Anyon Alpha - PRD Agent (Anyon - OhMyOpenCode)",
+    mode: MODE,
+    model,
+    temperature: 0.3,
+    maxTokens: 32000,
+    prompt: ANYON_ALPHA_SYSTEM_PROMPT,
+    permission: {
+      ...ANYON_ALPHA_PERMISSION,
+      ...restrictions.permission,
+    },
+    color: "#2196F3",
+  } as AgentConfig
+
+  if (isGptModel(model)) {
+    return { ...base, reasoningEffort: "high", textVerbosity: "high" } as AgentConfig
+  }
+
+  return { ...base, thinking: { type: "enabled", budgetTokens: 16000 } } as AgentConfig
+}
+createAnyonAlphaAgent.mode = MODE
 
 export { ANYON_ALPHA_IDENTITY_CONSTRAINTS } from "./identity-constraints"
 export { ANYON_ALPHA_INTERVIEW_MODE } from "./interview-mode"

--- a/src/agents/anyon-beta/index.ts
+++ b/src/agents/anyon-beta/index.ts
@@ -1,9 +1,15 @@
+import type { AgentConfig } from "@opencode-ai/sdk"
+import type { AgentMode, AgentPromptMetadata } from "../types"
+import { isGptModel } from "../types"
+import { createAgentToolRestrictions } from "../../shared/permission-compat"
 import { ANYON_BETA_IDENTITY_CONSTRAINTS } from "./identity-constraints"
 import { ANYON_BETA_INTERVIEW_MODE } from "./interview-mode"
 import { ANYON_BETA_DOCUMENT_GENERATION } from "./document-generation"
 import { ANYON_BETA_HIGH_ACCURACY_MODE } from "./high-accuracy-mode"
 import { ANYON_BETA_TEMPLATE } from "./template"
 import { ANYON_BETA_BEHAVIORAL_SUMMARY } from "./behavioral-summary"
+
+const MODE: AgentMode = "all"
 
 export const ANYON_BETA_SYSTEM_PROMPT = `${ANYON_BETA_IDENTITY_CONSTRAINTS}
 ${ANYON_BETA_INTERVIEW_MODE}
@@ -18,6 +24,52 @@ export const ANYON_BETA_PERMISSION = {
   webfetch: "allow" as const,
   question: "allow" as const,
 }
+
+export const ANYON_BETA_PROMPT_METADATA: AgentPromptMetadata = {
+  category: "specialist",
+  cost: "EXPENSIVE",
+  promptAlias: "Anyon Beta",
+  triggers: [
+    { domain: "UserFlow Design", trigger: "Screen flow design, user journey mapping from PRD" },
+  ],
+  useWhen: [
+    "PRD is complete and need UserFlow",
+    "Need to design screen-by-screen user journey",
+    "Planning UI structure before development",
+  ],
+  avoidWhen: [
+    "No PRD exists yet (use anyon-alpha first)",
+    "Technical implementation or code writing",
+    "Need data model design (use anyon-gamma)",
+  ],
+}
+
+export function createAnyonBetaAgent(model: string): AgentConfig {
+  const restrictions = createAgentToolRestrictions([
+    "call_omo_agent",
+  ])
+
+  const base = {
+    description: "Anyon Beta - UserFlow Agent (Anyon - OhMyOpenCode)",
+    mode: MODE,
+    model,
+    temperature: 0.3,
+    maxTokens: 32000,
+    prompt: ANYON_BETA_SYSTEM_PROMPT,
+    permission: {
+      ...ANYON_BETA_PERMISSION,
+      ...restrictions.permission,
+    },
+    color: "#4CAF50",
+  } as AgentConfig
+
+  if (isGptModel(model)) {
+    return { ...base, reasoningEffort: "high", textVerbosity: "high" } as AgentConfig
+  }
+
+  return { ...base, thinking: { type: "enabled", budgetTokens: 16000 } } as AgentConfig
+}
+createAnyonBetaAgent.mode = MODE
 
 export { ANYON_BETA_IDENTITY_CONSTRAINTS } from "./identity-constraints"
 export { ANYON_BETA_INTERVIEW_MODE } from "./interview-mode"

--- a/src/agents/anyon-gamma/index.ts
+++ b/src/agents/anyon-gamma/index.ts
@@ -1,9 +1,15 @@
+import type { AgentConfig } from "@opencode-ai/sdk"
+import type { AgentMode, AgentPromptMetadata } from "../types"
+import { isGptModel } from "../types"
+import { createAgentToolRestrictions } from "../../shared/permission-compat"
 import { ANYON_GAMMA_IDENTITY_CONSTRAINTS } from "./identity-constraints"
 import { ANYON_GAMMA_INTERVIEW_MODE } from "./interview-mode"
 import { ANYON_GAMMA_DOCUMENT_GENERATION } from "./document-generation"
 import { ANYON_GAMMA_HIGH_ACCURACY_MODE } from "./high-accuracy-mode"
 import { ANYON_GAMMA_TEMPLATE } from "./template"
 import { ANYON_GAMMA_BEHAVIORAL_SUMMARY } from "./behavioral-summary"
+
+const MODE: AgentMode = "all"
 
 export const ANYON_GAMMA_SYSTEM_PROMPT = `${ANYON_GAMMA_IDENTITY_CONSTRAINTS}
 ${ANYON_GAMMA_INTERVIEW_MODE}
@@ -18,6 +24,52 @@ export const ANYON_GAMMA_PERMISSION = {
   webfetch: "allow" as const,
   question: "allow" as const,
 }
+
+export const ANYON_GAMMA_PROMPT_METADATA: AgentPromptMetadata = {
+  category: "specialist",
+  cost: "EXPENSIVE",
+  promptAlias: "Anyon Gamma",
+  triggers: [
+    { domain: "Data Modeling", trigger: "ERD creation, database schema design from PRD+UserFlow" },
+  ],
+  useWhen: [
+    "PRD and UserFlow are complete",
+    "Need to design database structure / ERD",
+    "Planning data model before development",
+  ],
+  avoidWhen: [
+    "No PRD exists yet (use anyon-alpha first)",
+    "No UserFlow exists yet (use anyon-beta first)",
+    "Technical implementation or code writing",
+  ],
+}
+
+export function createAnyonGammaAgent(model: string): AgentConfig {
+  const restrictions = createAgentToolRestrictions([
+    "call_omo_agent",
+  ])
+
+  const base = {
+    description: "Anyon Gamma - ERD Agent (Anyon - OhMyOpenCode)",
+    mode: MODE,
+    model,
+    temperature: 0.3,
+    maxTokens: 32000,
+    prompt: ANYON_GAMMA_SYSTEM_PROMPT,
+    permission: {
+      ...ANYON_GAMMA_PERMISSION,
+      ...restrictions.permission,
+    },
+    color: "#9C27B0",
+  } as AgentConfig
+
+  if (isGptModel(model)) {
+    return { ...base, reasoningEffort: "high", textVerbosity: "high" } as AgentConfig
+  }
+
+  return { ...base, thinking: { type: "enabled", budgetTokens: 16000 } } as AgentConfig
+}
+createAnyonGammaAgent.mode = MODE
 
 export { ANYON_GAMMA_IDENTITY_CONSTRAINTS } from "./identity-constraints"
 export { ANYON_GAMMA_INTERVIEW_MODE } from "./interview-mode"

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -23,16 +23,22 @@ export {
 } from "./prometheus"
 
 export {
+  createAnyonAlphaAgent,
   ANYON_ALPHA_SYSTEM_PROMPT,
   ANYON_ALPHA_PERMISSION,
+  ANYON_ALPHA_PROMPT_METADATA,
 } from "./anyon-alpha"
 
 export {
+  createAnyonBetaAgent,
   ANYON_BETA_SYSTEM_PROMPT,
   ANYON_BETA_PERMISSION,
+  ANYON_BETA_PROMPT_METADATA,
 } from "./anyon-beta"
 
 export {
+  createAnyonGammaAgent,
   ANYON_GAMMA_SYSTEM_PROMPT,
   ANYON_GAMMA_PERMISSION,
+  ANYON_GAMMA_PROMPT_METADATA,
 } from "./anyon-gamma"

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -80,6 +80,9 @@ export type BuiltinAgentName =
   | "metis"
   | "momus"
   | "atlas"
+  | "anyon-alpha"
+  | "anyon-beta"
+  | "anyon-gamma"
 
 export type OverridableAgentName =
   | "build"

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -10,6 +10,9 @@ import { createMetisAgent, metisPromptMetadata } from "./metis"
 import { createAtlasAgent, atlasPromptMetadata } from "./atlas"
 import { createMomusAgent, momusPromptMetadata } from "./momus"
 import { createHephaestusAgent } from "./hephaestus"
+import { createAnyonAlphaAgent, ANYON_ALPHA_PROMPT_METADATA } from "./anyon-alpha"
+import { createAnyonBetaAgent, ANYON_BETA_PROMPT_METADATA } from "./anyon-beta"
+import { createAnyonGammaAgent, ANYON_GAMMA_PROMPT_METADATA } from "./anyon-gamma"
 import type { AvailableAgent, AvailableCategory, AvailableSkill } from "./dynamic-agent-prompt-builder"
 import { deepMerge, fetchAvailableModels, resolveModelPipeline, AGENT_MODEL_REQUIREMENTS, readConnectedProvidersCache, isModelAvailable, isAnyFallbackModelAvailable, migrateAgentConfig } from "../shared"
 import { DEFAULT_CATEGORIES, CATEGORY_DESCRIPTIONS } from "../tools/delegate-task/constants"
@@ -32,6 +35,9 @@ const agentSources: Record<BuiltinAgentName, AgentSource> = {
   // Note: Atlas is handled specially in createBuiltinAgents()
   // because it needs OrchestratorContext, not just a model string
   atlas: createAtlasAgent as unknown as AgentFactory,
+  "anyon-alpha": createAnyonAlphaAgent,
+  "anyon-beta": createAnyonBetaAgent,
+  "anyon-gamma": createAnyonGammaAgent,
 }
 
 /**
@@ -46,6 +52,9 @@ const agentMetadata: Partial<Record<BuiltinAgentName, AgentPromptMetadata>> = {
   metis: metisPromptMetadata,
   momus: momusPromptMetadata,
   atlas: atlasPromptMetadata,
+  "anyon-alpha": ANYON_ALPHA_PROMPT_METADATA,
+  "anyon-beta": ANYON_BETA_PROMPT_METADATA,
+  "anyon-gamma": ANYON_GAMMA_PROMPT_METADATA,
 }
 
 function isFactory(source: AgentSource): source is AgentFactory {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -27,6 +27,9 @@ export const BuiltinAgentNameSchema = z.enum([
   "metis",
   "momus",
   "atlas",
+  "anyon-alpha",
+  "anyon-beta",
+  "anyon-gamma",
 ])
 
 export const BuiltinSkillNameSchema = z.enum([
@@ -51,6 +54,9 @@ export const OverridableAgentNameSchema = z.enum([
   "explore",
   "multimodal-looker",
   "atlas",
+  "anyon-alpha",
+  "anyon-beta",
+  "anyon-gamma",
 ])
 
 export const AgentNameSchema = BuiltinAgentNameSchema
@@ -152,6 +158,9 @@ export const AgentOverridesSchema = z.object({
   explore: AgentOverrideConfigSchema.optional(),
   "multimodal-looker": AgentOverrideConfigSchema.optional(),
   atlas: AgentOverrideConfigSchema.optional(),
+  "anyon-alpha": AgentOverrideConfigSchema.optional(),
+  "anyon-beta": AgentOverrideConfigSchema.optional(),
+  "anyon-gamma": AgentOverrideConfigSchema.optional(),
 })
 
 export const ClaudeCodeConfigSchema = z.object({

--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -31,9 +31,7 @@ import { migrateAgentConfig } from "../shared/permission-compat";
 import { AGENT_NAME_MAP } from "../shared/migration";
 import { AGENT_MODEL_REQUIREMENTS } from "../shared/model-requirements";
 import { PROMETHEUS_SYSTEM_PROMPT, PROMETHEUS_PERMISSION } from "../agents/prometheus";
-import { ANYON_ALPHA_SYSTEM_PROMPT, ANYON_ALPHA_PERMISSION } from "../agents/anyon-alpha";
-import { ANYON_BETA_SYSTEM_PROMPT, ANYON_BETA_PERMISSION } from "../agents/anyon-beta";
-import { ANYON_GAMMA_SYSTEM_PROMPT, ANYON_GAMMA_PERMISSION } from "../agents/anyon-gamma";
+
 import { DEFAULT_CATEGORIES } from "../tools/delegate-task/constants";
 import type { ModelCacheState } from "../plugin-state";
 import type { CategoryConfig } from "../config/schema";
@@ -337,33 +335,6 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
         } else {
           agentConfig["prometheus"] = prometheusBase;
         }
-      }
-
-      agentConfig["anyon-alpha"] = {
-        name: "anyon-alpha",
-        mode: "all" as const,
-        prompt: ANYON_ALPHA_SYSTEM_PROMPT,
-        permission: ANYON_ALPHA_PERMISSION,
-        description: "Anyon Alpha - PRD Agent (Anyon - OhMyOpenCode)",
-        color: "#2196F3",
-      }
-
-      agentConfig["anyon-beta"] = {
-        name: "anyon-beta",
-        mode: "all" as const,
-        prompt: ANYON_BETA_SYSTEM_PROMPT,
-        permission: ANYON_BETA_PERMISSION,
-        description: "Anyon Beta - UserFlow Agent (Anyon - OhMyOpenCode)",
-        color: "#4CAF50",
-      }
-
-      agentConfig["anyon-gamma"] = {
-        name: "anyon-gamma",
-        mode: "all" as const,
-        prompt: ANYON_GAMMA_SYSTEM_PROMPT,
-        permission: ANYON_GAMMA_PERMISSION,
-        description: "Anyon Gamma - ERD Agent (Anyon - OhMyOpenCode)",
-        color: "#9C27B0",
       }
 
     const filteredConfigAgents = configAgent

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -94,6 +94,27 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro" },
     ],
   },
+  "anyon-alpha": {
+    fallbackChain: [
+      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "high" },
+      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro" },
+    ],
+  },
+  "anyon-beta": {
+    fallbackChain: [
+      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "high" },
+      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro" },
+    ],
+  },
+  "anyon-gamma": {
+    fallbackChain: [
+      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "high" },
+      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro" },
+    ],
+  },
 }
 
 export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {


### PR DESCRIPTION
## Summary

Anyon agents (Alpha/Beta/Gamma) were previously registered only via plugin-level config-handler. This PR integrates them into oh-my-opencode's native agent system following established patterns (oracle, metis, etc.).

## Changes

### P0 — Critical (#3, #4)
- **Factory functions**: `createAnyonAlphaAgent()`, `createAnyonBetaAgent()`, `createAnyonGammaAgent()` following oracle/metis pattern
- **agentSources registry**: All 3 agents registered in `agents/utils.ts`

### P1 — High (#5, #6)
- **BuiltinAgentName type**: Added to union type + zod schema + OverridableAgentNameSchema + AgentOverridesSchema
- **Model fallback chains**: `claude-opus-4-5` → `gpt-5.2` → `gemini-3-pro` (planning-tier)

### P2 — Medium (#7, #8)
- **agentMetadata**: Sisyphus delegation prompt now shows Anyon agents with triggers, useWhen, avoidWhen
- **Tool restrictions**: `call_omo_agent: deny` enforced at factory level; `websearch/google_search: deny` via config-handler

### P3 — Low (#9, #10)
- **Thinking config**: `temperature: 0.3`, `budgetTokens: 16000` (Claude), `reasoningEffort: high` (GPT)
- **Pipeline handoff**: Already implemented in behavioral-summary prompts

### Cleanup
- Removed manual agent registration from `config-handler.ts` (now handled by native `createBuiltinAgents()`)
- Kept runtime permission augmentation in config-handler (delegate_task, question, websearch deny)

## Verification
- `bun run build` ✅ (2.90MB)
- `bun run typecheck` ✅
- Registration verified across all 7 files by automated review

Closes #3, #4, #5, #6, #7, #8, #9, #10, #11