### PR TITLE
docs: add comprehensive developer guide for fork customization

### DIFF
--- a/docs/developer-guide/00-architecture-overview.md
+++ b/docs/developer-guide/00-architecture-overview.md
@@ -1,0 +1,380 @@
+# Architecture Overview
+
+This document provides a comprehensive overview of oh-my-opencode's architecture for developers who want to fork and customize the project.
+
+## Table of Contents
+
+- [High-Level Architecture](#high-level-architecture)
+- [Core Components](#core-components)
+- [Data Flow](#data-flow)
+- [Extension Points](#extension-points)
+- [Directory Structure](#directory-structure)
+- [Key Patterns](#key-patterns)
+
+---
+
+## High-Level Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              OpenCode Runtime                                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│   ┌─────────────────────────────────────────────────────────────────────┐   │
+│   │                     oh-my-opencode Plugin                           │   │
+│   ├─────────────────────────────────────────────────────────────────────┤   │
+│   │                                                                     │   │
+│   │  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────────────┐   │   │
+│   │  │  Agents  │  │  Hooks   │  │  Tools   │  │  Features        │   │   │
+│   │  │  (11)    │  │  (34)    │  │  (20+)   │  │  (Background,    │   │   │
+│   │  │          │  │          │  │          │  │   Skills, MCPs)  │   │   │
+│   │  └──────────┘  └──────────┘  └──────────┘  └──────────────────┘   │   │
+│   │       │              │             │                │              │   │
+│   │       └──────────────┴─────────────┴────────────────┘              │   │
+│   │                              │                                      │   │
+│   │                    ┌─────────▼─────────┐                           │   │
+│   │                    │    Plugin Entry   │                           │   │
+│   │                    │    (index.ts)     │                           │   │
+│   │                    └───────────────────┘                           │   │
+│   │                                                                     │   │
+│   └─────────────────────────────────────────────────────────────────────┘   │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+oh-my-opencode is an **OpenCode plugin** that extends the base OpenCode functionality with:
+
+1. **Multi-model agent orchestration** - 11 specialized AI agents
+2. **Lifecycle hooks** - 34 hooks for customizing behavior
+3. **Extended tools** - LSP, AST-grep, delegation, and more
+4. **Background agent management** - Parallel task execution
+5. **Skill system** - Reusable prompt injection
+6. **MCP integration** - External tool servers
+
+---
+
+## Core Components
+
+### 1. Agents (`src/agents/`)
+
+Agents are AI personalities with specific roles and capabilities.
+
+| Agent | Model | Role |
+|-------|-------|------|
+| **Sisyphus** | Claude Opus 4.5 | Primary orchestrator - delegates work to specialists |
+| **Hephaestus** | GPT 5.2 Codex | Autonomous deep worker - goal-oriented execution |
+| **Atlas** | Claude Sonnet 4.5 | Master orchestrator - holds todo list |
+| **Oracle** | GPT 5.2 | Read-only consultant - architecture & debugging |
+| **Librarian** | GLM 4.7 | Research agent - docs, GitHub, external references |
+| **Explore** | Grok Code Fast | Fast codebase grep - contextual search |
+| **Prometheus** | Claude Opus 4.5 | Strategic planner - interview-based planning |
+| **Metis** | Claude Opus 4.5 | Pre-planning analysis - gap detection |
+| **Momus** | GPT 5.2 | Plan reviewer - ruthless fault-finding |
+| **Multimodal-Looker** | Gemini 3 Flash | Media analyzer - PDFs, images |
+| **Sisyphus-Junior** | Claude Sonnet 4.5 | Category-spawned executor |
+
+**Key Concept**: Agents have **modes**:
+- `primary` - Respects user's UI model selection
+- `subagent` - Uses own fallback chain, ignores UI selection
+
+### 2. Hooks (`src/hooks/`)
+
+Hooks intercept and modify behavior at specific lifecycle points.
+
+| Hook Type | When Triggered | Use Case |
+|-----------|----------------|----------|
+| `PreToolUse` | Before any tool executes | Validation, modification |
+| `PostToolUse` | After tool completes | Result transformation |
+| `UserPromptSubmit` | When user sends message | Context injection |
+| `Stop` | When agent stops | Cleanup, continuation |
+| `SessionStart` | New session begins | Initialization |
+| `MessagesTransform` | Before messages sent to model | Context modification |
+
+**Performance Note**: `PreToolUse` hooks run on EVERY tool call. Keep them lightweight.
+
+### 3. Tools (`src/tools/`)
+
+Tools are capabilities the agent can invoke.
+
+| Category | Tools | Purpose |
+|----------|-------|---------|
+| **LSP** | 6 tools | goto_definition, find_references, symbols, diagnostics, rename |
+| **AST** | 2 tools | ast_grep_search, ast_grep_replace |
+| **Search** | 2 tools | grep, glob |
+| **Session** | 4 tools | list, read, search, info |
+| **Delegation** | 2 tools | delegate_task, call_omo_agent |
+| **Background** | 2 tools | background_output, background_cancel |
+
+### 4. Features (`src/features/`)
+
+Features are complex subsystems that combine multiple components.
+
+| Feature | Purpose |
+|---------|---------|
+| `background-agent/` | Parallel task execution with concurrency control |
+| `builtin-skills/` | Core skills (playwright, git-master, frontend-ui-ux) |
+| `opencode-skill-loader/` | Skill discovery from multiple directories |
+| `skill-mcp-manager/` | MCP server lifecycle management |
+| `context-injector/` | AGENTS.md, README injection |
+| `boulder-state/` | Todo persistence across sessions |
+
+### 5. Config (`src/config/`)
+
+Configuration with Zod validation and JSONC support.
+
+```
+Config Priority:
+1. Project: .opencode/oh-my-opencode.json
+2. User: ~/.config/opencode/oh-my-opencode.json
+```
+
+---
+
+## Data Flow
+
+### Agent Invocation Flow
+
+```
+User Message
+     │
+     ▼
+┌────────────────┐
+│ UserPromptSubmit│  ← Hooks inject context
+│    Hooks       │
+└────────────────┘
+     │
+     ▼
+┌────────────────┐
+│  Main Agent    │  ← Sisyphus/Atlas
+│  (Orchestrator)│
+└────────────────┘
+     │
+     ├─── Direct Tool Use ───────────────────────────────┐
+     │         │                                          │
+     │         ▼                                          │
+     │    ┌──────────┐    ┌──────────┐    ┌──────────┐  │
+     │    │PreToolUse│ →  │  Tool    │ →  │PostToolUse│  │
+     │    │  Hooks   │    │ Execute  │    │  Hooks   │  │
+     │    └──────────┘    └──────────┘    └──────────┘  │
+     │                                                    │
+     └─── delegate_task ─────────────────────────────────┤
+               │                                          │
+               ▼                                          │
+          ┌──────────────┐                               │
+          │  Background  │  ← Async execution            │
+          │   Manager    │                               │
+          └──────────────┘                               │
+               │                                          │
+               ▼                                          │
+          ┌──────────────┐                               │
+          │  Subagent    │  ← Oracle, Explore, etc.     │
+          │  Session     │                               │
+          └──────────────┘                               │
+               │                                          │
+               ▼                                          │
+          ┌──────────────┐                               │
+          │   Result     │ ─────────────────────────────┘
+          └──────────────┘
+```
+
+### Delegation Flow
+
+```
+delegate_task(category="visual-engineering", load_skills=["frontend-ui-ux"])
+                    │
+                    ▼
+           ┌───────────────────┐
+           │  Resolve Category │
+           │  → Model config   │
+           │  → Temperature    │
+           │  → Prompt append  │
+           └───────────────────┘
+                    │
+                    ▼
+           ┌───────────────────┐
+           │  Resolve Skills   │
+           │  → Load SKILL.md  │
+           │  → Inject prompt  │
+           └───────────────────┘
+                    │
+                    ▼
+           ┌───────────────────┐
+           │  Spawn Agent      │
+           │  → Sisyphus-Junior│
+           │  → With category  │
+           │    model config   │
+           └───────────────────┘
+```
+
+---
+
+## Extension Points
+
+oh-my-opencode provides multiple extension points for customization:
+
+| Extension | How to Add | Complexity |
+|-----------|------------|------------|
+| **New Agent** | Create factory in `src/agents/` | Medium |
+| **New Hook** | Create factory in `src/hooks/` | Low-Medium |
+| **New Tool** | Create directory in `src/tools/` | Medium |
+| **New Skill** | Add `SKILL.md` in skills directory | Low |
+| **New Category** | Add to config `categories` | Low |
+| **New MCP** | Add config in `src/mcp/` | Medium |
+
+See individual guides for detailed instructions:
+- [01-agent-system.md](./01-agent-system.md) - Adding agents
+- [02-hook-system.md](./02-hook-system.md) - Adding hooks
+- [03-tool-system.md](./03-tool-system.md) - Adding tools
+- [05-skill-system.md](./05-skill-system.md) - Adding skills
+
+---
+
+## Directory Structure
+
+```
+oh-my-opencode/
+├── src/
+│   ├── index.ts                 # Plugin entry point (788 lines)
+│   │
+│   ├── agents/                  # 11 AI agents
+│   │   ├── sisyphus.ts          # Main orchestrator
+│   │   ├── oracle.ts            # Consultation agent
+│   │   ├── types.ts             # AgentConfig, AgentPromptMetadata
+│   │   ├── utils.ts             # createBuiltinAgents(), model resolution
+│   │   └── dynamic-agent-prompt-builder.ts  # Sisyphus prompt generation
+│   │
+│   ├── hooks/                   # 34 lifecycle hooks
+│   │   ├── todo-continuation/   # Enforces task completion
+│   │   ├── context-window/      # Monitors token usage
+│   │   ├── comment-checker/     # Prevents comment bloat
+│   │   └── [hook-name]/         # Each hook in its directory
+│   │
+│   ├── tools/                   # 20+ tools
+│   │   ├── lsp/                 # 6 LSP tools
+│   │   ├── ast-grep/            # AST search/replace
+│   │   ├── delegate-task/       # Task delegation (1135 lines)
+│   │   └── [tool-name]/         # Standard structure
+│   │
+│   ├── features/                # Complex subsystems
+│   │   ├── background-agent/    # Async task management (1418 lines)
+│   │   ├── builtin-skills/      # Core skills (1729 lines)
+│   │   ├── opencode-skill-loader/
+│   │   └── skill-mcp-manager/
+│   │
+│   ├── mcp/                     # Built-in MCP servers
+│   │   ├── websearch.ts         # Exa search
+│   │   ├── context7.ts          # Documentation
+│   │   └── grep_app.ts          # GitHub code search
+│   │
+│   ├── config/                  # Configuration
+│   │   └── schema.ts            # Zod validation schema
+│   │
+│   └── shared/                  # 66 utilities
+│       ├── model-resolution.ts  # Fallback chains
+│       └── agent-tool-restrictions.ts
+│
+├── docs/
+│   ├── developer-guide/         # You are here
+│   ├── guide/                   # User guides
+│   └── configurations.md        # Config reference
+│
+└── script/                      # Build scripts
+    └── build-schema.ts          # JSON schema generation
+```
+
+---
+
+## Key Patterns
+
+### 1. Factory Pattern
+
+All agents, hooks, and most tools use factory functions:
+
+```typescript
+// Agent factory
+export function createOracleAgent(model: string): AgentConfig {
+  return {
+    name: "oracle",
+    model,
+    description: "Strategic advisor...",
+    prompt: ORACLE_SYSTEM_PROMPT,
+    temperature: 0.1,
+  }
+}
+createOracleAgent.mode = "subagent" as const
+
+// Hook factory
+export function createMyHook(ctx: PluginInput) {
+  return {
+    preToolUse: async (input) => { /* ... */ },
+    postToolUse: async (input) => { /* ... */ },
+  }
+}
+
+// Tool factory
+export function createDelegateTask(options): ToolDefinition {
+  return tool({
+    description: "...",
+    args: { /* ... */ },
+    execute: async (args, ctx) => { /* ... */ },
+  })
+}
+```
+
+### 2. Metadata Pattern
+
+Agents expose metadata for dynamic prompt generation:
+
+```typescript
+export const ORACLE_PROMPT_METADATA: AgentPromptMetadata = {
+  category: "advisor",
+  cost: "EXPENSIVE",
+  triggers: [
+    { domain: "Architecture decisions", trigger: "Multi-system tradeoffs" },
+  ],
+  useWhen: ["Complex debugging", "After 2+ failed fixes"],
+  avoidWhen: ["Simple file operations", "First attempt at fix"],
+}
+```
+
+This metadata is used by `dynamic-agent-prompt-builder.ts` to generate Sisyphus's delegation tables automatically.
+
+### 3. Model Fallback Chain
+
+Agents define fallback chains for model availability:
+
+```typescript
+// In shared/model-requirements.ts
+export const AGENT_MODEL_REQUIREMENTS = {
+  sisyphus: {
+    fallbackChain: [
+      { providers: ["anthropic"], model: "claude-opus-4-5" },
+      { providers: ["kimi"], model: "k2.5" },
+      { providers: ["openai"], model: "gpt-5.2-codex" },
+    ]
+  }
+}
+```
+
+### 4. Tool Restrictions
+
+Agents have restricted tool access to enforce roles:
+
+```typescript
+// Read-only agents can't write
+export function getAgentToolRestrictions(agentName: string) {
+  if (agentName === "oracle") {
+    return { write: false, edit: false, task: false, delegate_task: false }
+  }
+  // ...
+}
+```
+
+---
+
+## Next Steps
+
+1. **[01-agent-system.md](./01-agent-system.md)** - Deep dive into agents
+2. **[02-hook-system.md](./02-hook-system.md)** - Hook implementation guide
+3. **[03-tool-system.md](./03-tool-system.md)** - Tool creation guide
+4. **[04-delegation-orchestration.md](./04-delegation-orchestration.md)** - Orchestration mechanics

--- a/docs/developer-guide/01-agent-system.md
+++ b/docs/developer-guide/01-agent-system.md
@@ -1,0 +1,642 @@
+# Agent System Guide
+
+This guide explains how the agent system works and how to add new agents to oh-my-opencode.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Agent Architecture](#agent-architecture)
+- [Agent Types](#agent-types)
+- [Creating a New Agent](#creating-a-new-agent)
+- [Agent Prompt Metadata](#agent-prompt-metadata)
+- [Model Fallback Chains](#model-fallback-chains)
+- [Tool Restrictions](#tool-restrictions)
+- [Registration Process](#registration-process)
+- [Best Practices](#best-practices)
+
+---
+
+## Overview
+
+Agents in oh-my-opencode are specialized AI personalities that:
+- Have specific roles and responsibilities
+- Use optimized models for their task domain
+- Have restricted tool access based on their role
+- Can be invoked via `delegate_task` or directly
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Agent Hierarchy                          │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  Primary Agents (UI model selection respected)              │
+│  ├── Sisyphus      → Main orchestrator                     │
+│  ├── Atlas         → Master orchestrator (holds todos)     │
+│  └── Prometheus    → Strategic planner                     │
+│                                                             │
+│  Subagents (own fallback chains)                           │
+│  ├── Oracle        → Read-only consultation                │
+│  ├── Librarian     → External research                     │
+│  ├── Explore       → Fast codebase search                  │
+│  ├── Hephaestus    → Autonomous deep worker                │
+│  ├── Metis         → Pre-planning analysis                 │
+│  ├── Momus         → Plan review                           │
+│  ├── Multimodal    → Media analysis                        │
+│  └── Sisyphus-Junior → Category-spawned executor           │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Agent Architecture
+
+### Core Types
+
+```typescript
+// src/agents/types.ts
+
+// Agent mode determines UI model selection behavior
+type AgentMode = "primary" | "subagent" | "all"
+
+// Factory function signature
+type AgentFactory = ((model: string) => AgentConfig) & {
+  mode: AgentMode
+}
+
+// Agent configuration (from OpenCode SDK)
+interface AgentConfig {
+  name: string
+  description: string
+  prompt: string           // System prompt
+  model?: string           // e.g., "anthropic/claude-opus-4-5"
+  temperature?: number     // 0.1 for code, 0.3 for analysis
+  variant?: string         // "max", "medium", "high"
+  thinking?: {
+    budget: number         // Token budget for thinking
+  }
+}
+
+// Metadata for Sisyphus prompt generation
+interface AgentPromptMetadata {
+  category: "exploration" | "specialist" | "advisor" | "utility"
+  cost: "FREE" | "CHEAP" | "EXPENSIVE"
+  triggers: DelegationTrigger[]
+  useWhen?: string[]
+  avoidWhen?: string[]
+  keyTrigger?: string
+  dedicatedSection?: string
+}
+```
+
+### Agent Modes Explained
+
+| Mode | Behavior | Example Agents |
+|------|----------|----------------|
+| `primary` | Respects user's UI model selection. If user selects "claude-sonnet" in UI, agent uses it. | Sisyphus, Atlas, Prometheus |
+| `subagent` | Ignores UI selection. Uses own fallback chain for optimal model. | Oracle, Explore, Librarian |
+| `all` | Available in both contexts. OpenCode compatibility. | - |
+
+---
+
+## Agent Types
+
+### Primary Agents
+
+**Sisyphus** - Main orchestrator
+```typescript
+// The "boss" agent that:
+// - Receives user requests
+// - Delegates to specialist agents
+// - Coordinates work completion
+// - Uses dynamic prompt with delegation tables
+```
+
+**Atlas** - Master orchestrator
+```typescript
+// Alternative orchestrator that:
+// - Holds and manages the todo list
+// - Provides structured task tracking
+// - Works with Sisyphus delegation system
+```
+
+**Prometheus** - Strategic planner
+```typescript
+// Planning specialist that:
+// - Conducts requirements interviews
+// - Creates detailed work plans
+// - Never implements - planning only
+```
+
+### Subagents
+
+**Oracle** - Read-only consultant
+```typescript
+// High-IQ consultation agent:
+// - Architecture decisions
+// - Complex debugging
+// - CANNOT write/edit files
+// - Expensive but accurate
+```
+
+**Explore** - Fast codebase search
+```typescript
+// Contextual grep specialist:
+// - Fast and cheap
+// - Multiple search angles
+// - Pattern discovery
+// - CANNOT write/edit
+```
+
+**Librarian** - External research
+```typescript
+// Research specialist:
+// - Official documentation
+// - GitHub code search
+// - OSS implementation examples
+// - Context7, grep.app integration
+```
+
+---
+
+## Creating a New Agent
+
+### Step 1: Create the Agent File
+
+Create `src/agents/my-agent.ts`:
+
+```typescript
+import type { AgentConfig } from "@opencode-ai/sdk"
+import type { AgentFactory, AgentPromptMetadata } from "./types"
+
+// System prompt for your agent
+const MY_AGENT_SYSTEM_PROMPT = `
+You are a specialized agent for [DOMAIN].
+
+## Your Role
+- [Primary responsibility]
+- [Secondary responsibility]
+
+## Guidelines
+- [Guideline 1]
+- [Guideline 2]
+
+## Constraints
+- [What you should NOT do]
+`
+
+// Agent factory function
+export function createMyAgent(model: string): AgentConfig {
+  return {
+    name: "my-agent",
+    description: "Brief description of what this agent does",
+    model,
+    prompt: MY_AGENT_SYSTEM_PROMPT,
+    temperature: 0.1,  // Low for code, higher for creative tasks
+    // Optional: thinking budget for complex reasoning
+    thinking: {
+      budget: 16000,  // Token budget
+    },
+  }
+}
+
+// CRITICAL: Set the agent mode
+createMyAgent.mode = "subagent" as const  // or "primary"
+
+// Metadata for Sisyphus prompt generation
+export const MY_AGENT_PROMPT_METADATA: AgentPromptMetadata = {
+  category: "specialist",  // exploration | specialist | advisor | utility
+  cost: "CHEAP",           // FREE | CHEAP | EXPENSIVE
+  triggers: [
+    {
+      domain: "Your Domain",
+      trigger: "When to use this agent",
+    },
+  ],
+  useWhen: [
+    "Specific scenario 1",
+    "Specific scenario 2",
+  ],
+  avoidWhen: [
+    "When NOT to use this agent",
+  ],
+  // Optional: appears in Phase 0 Key Triggers
+  keyTrigger: "Trigger phrase → fire my-agent",
+}
+```
+
+### Step 2: Add to Agent Sources
+
+Edit `src/agents/utils.ts`:
+
+```typescript
+import { createMyAgent, MY_AGENT_PROMPT_METADATA } from "./my-agent"
+
+// Add to agent sources
+const agentSources: Record<BuiltinAgentName, AgentSource> = {
+  // ... existing agents
+  "my-agent": createMyAgent,
+}
+
+// Add metadata for Sisyphus prompt generation
+const agentMetadata: Partial<Record<BuiltinAgentName, AgentPromptMetadata>> = {
+  // ... existing metadata
+  "my-agent": MY_AGENT_PROMPT_METADATA,
+}
+```
+
+### Step 3: Update Type Definitions
+
+Edit `src/agents/types.ts`:
+
+```typescript
+export type BuiltinAgentName =
+  | "sisyphus"
+  | "oracle"
+  // ... existing agents
+  | "my-agent"  // Add your agent
+```
+
+### Step 4: Update Config Schema
+
+Edit `src/config/schema.ts`:
+
+```typescript
+export const AgentNameSchema = z.enum([
+  "sisyphus",
+  "oracle",
+  // ... existing agents
+  "my-agent",  // Add your agent
+])
+```
+
+### Step 5: Export from Index
+
+Edit `src/agents/index.ts`:
+
+```typescript
+export { createMyAgent, MY_AGENT_PROMPT_METADATA } from "./my-agent"
+```
+
+### Step 6: Build and Test
+
+```bash
+# Rebuild schema
+bun run build:schema
+
+# Full build
+bun run build
+
+# Test locally in OpenCode
+```
+
+---
+
+## Agent Prompt Metadata
+
+Metadata drives **dynamic Sisyphus prompt generation**. Instead of hardcoding delegation tables, the system generates them from agent metadata.
+
+### How It Works
+
+```
+Agent Metadata           dynamic-agent-prompt-builder.ts         Sisyphus Prompt
+     │                              │                                  │
+     ▼                              ▼                                  ▼
+┌─────────────┐              ┌─────────────────┐              ┌─────────────────┐
+│ category    │──────────────│ buildKeyTriggers│──────────────│ Phase 0 Triggers│
+│ cost        │              │ buildToolSelect │              │ Tool Selection  │
+│ triggers    │              │ buildDelegation │              │ Delegation Table│
+│ useWhen     │              │ buildOracleSection│            │ Oracle Section  │
+│ avoidWhen   │              └─────────────────┘              └─────────────────┘
+└─────────────┘
+```
+
+### Metadata Fields Explained
+
+```typescript
+interface AgentPromptMetadata {
+  // Groups agent in Sisyphus prompt sections
+  category: "exploration" | "specialist" | "advisor" | "utility"
+  
+  // Appears in Tool & Agent Selection table
+  cost: "FREE" | "CHEAP" | "EXPENSIVE"
+  
+  // Generates Delegation Table rows
+  triggers: [{
+    domain: "Frontend UI/UX",       // Domain column
+    trigger: "Visual changes only"  // Trigger column
+  }]
+  
+  // When to use (for detailed sections)
+  useWhen: ["Complex debugging", "Architecture review"]
+  
+  // When NOT to use
+  avoidWhen: ["Simple file operations", "First attempt"]
+  
+  // Appears in Phase 0 Key Triggers (BEFORE classification)
+  keyTrigger: "External library mentioned → fire librarian"
+  
+  // Optional: full markdown section for complex agents (like Oracle)
+  dedicatedSection: "## Oracle Usage\n..."
+}
+```
+
+### Example: Oracle Metadata
+
+```typescript
+export const ORACLE_PROMPT_METADATA: AgentPromptMetadata = {
+  category: "advisor",
+  cost: "EXPENSIVE",
+  triggers: [
+    { domain: "Architecture decisions", trigger: "Multi-system tradeoffs" },
+    { domain: "Self-review", trigger: "After completing significant implementation" },
+    { domain: "Hard debugging", trigger: "After 2+ failed fix attempts" },
+  ],
+  useWhen: [
+    "Complex architecture design",
+    "2+ failed fix attempts",
+    "Unfamiliar code patterns",
+    "Security/performance concerns",
+  ],
+  avoidWhen: [
+    "Simple file operations (use direct tools)",
+    "First attempt at any fix (try yourself first)",
+    "Questions answerable from code you've read",
+    "Trivial decisions (variable names, formatting)",
+  ],
+}
+```
+
+---
+
+## Model Fallback Chains
+
+Agents specify fallback chains for when primary models are unavailable.
+
+### Defining Fallback Chains
+
+Edit `src/shared/model-requirements.ts`:
+
+```typescript
+export const AGENT_MODEL_REQUIREMENTS: Record<string, AgentModelRequirement> = {
+  "my-agent": {
+    // Try these models in order
+    fallbackChain: [
+      { providers: ["anthropic"], model: "claude-sonnet-4-5" },
+      { providers: ["openai"], model: "gpt-5.2" },
+      { providers: ["google"], model: "gemini-3-flash" },
+    ],
+    // Optional: require specific model (no fallback)
+    // requiresModel: "openai/gpt-5.2-codex",
+    
+    // Optional: require at least one model from chain to be available
+    // requiresAnyModel: true,
+  },
+}
+```
+
+### How Resolution Works
+
+```typescript
+// Resolution priority:
+// 1. User-specified model (from config override)
+// 2. UI-selected model (for primary agents)
+// 3. Fallback chain (try each in order)
+// 4. System default model
+
+const resolution = resolveModelPipeline({
+  intent: { uiSelectedModel, userModel },
+  constraints: { availableModels },
+  policy: { fallbackChain, systemDefaultModel },
+})
+```
+
+---
+
+## Tool Restrictions
+
+Restrict which tools an agent can use based on its role.
+
+### Defining Restrictions
+
+Edit `src/shared/agent-tool-restrictions.ts`:
+
+```typescript
+export function getAgentToolRestrictions(agentName: string) {
+  // Read-only agents
+  if (agentName === "oracle" || agentName === "my-agent") {
+    return {
+      write: false,
+      edit: false,
+      task: false,
+      delegate_task: false,
+    }
+  }
+  
+  // Exploration agents (no recursion)
+  if (agentName === "explore" || agentName === "librarian") {
+    return {
+      write: false,
+      edit: false,
+      task: false,
+      delegate_task: false,
+      call_omo_agent: false,
+    }
+  }
+  
+  // Allow all tools by default
+  return {}
+}
+```
+
+### Alternative: Tool Allowlist
+
+For very restricted agents:
+
+```typescript
+export function createAgentToolAllowlist(tools: string[]) {
+  // Only these tools are allowed, all others denied
+  return { allowlist: tools }
+}
+
+// Usage: multimodal-looker only gets 'read'
+if (agentName === "multimodal-looker") {
+  return createAgentToolAllowlist(["read"])
+}
+```
+
+---
+
+## Registration Process
+
+### Complete Checklist
+
+When adding a new agent, ensure you:
+
+- [ ] Create `src/agents/my-agent.ts` with factory and metadata
+- [ ] Add to `agentSources` in `src/agents/utils.ts`
+- [ ] Add metadata to `agentMetadata` in `src/agents/utils.ts`
+- [ ] Update `BuiltinAgentName` type in `src/agents/types.ts`
+- [ ] Update `AgentNameSchema` in `src/config/schema.ts`
+- [ ] Export from `src/agents/index.ts`
+- [ ] Add model requirements in `src/shared/model-requirements.ts` (if needed)
+- [ ] Add tool restrictions in `src/shared/agent-tool-restrictions.ts` (if needed)
+- [ ] Run `bun run build:schema` to update JSON schema
+- [ ] Run `bun run build` to verify
+- [ ] Test agent invocation via `delegate_task`
+
+### Testing Your Agent
+
+```typescript
+// Test via delegate_task
+delegate_task(
+  subagent_type="my-agent",
+  load_skills=[],
+  run_in_background=false,
+  prompt="Test prompt for my agent"
+)
+
+// Or via category if you added one
+delegate_task(
+  category="my-category",
+  load_skills=["relevant-skill"],
+  run_in_background=false,
+  prompt="Test prompt"
+)
+```
+
+---
+
+## Best Practices
+
+### 1. Single Responsibility
+
+Each agent should have ONE clear purpose:
+- ✅ "Explore - fast codebase grep"
+- ✅ "Oracle - read-only consultation"
+- ❌ "Helper - does everything"
+
+### 2. Appropriate Temperature
+
+| Task Type | Temperature |
+|-----------|-------------|
+| Code generation | 0.1 |
+| Code review | 0.1 |
+| Creative writing | 0.5-0.7 |
+| Analysis | 0.3 |
+
+### 3. Clear Constraints
+
+Be explicit about what the agent should NOT do:
+
+```typescript
+const PROMPT = `
+## Constraints
+- NEVER modify files directly - you are read-only
+- NEVER suggest changes without evidence
+- NEVER speculate about code you haven't read
+`
+```
+
+### 4. Thinking Budget
+
+For complex reasoning agents, allocate thinking budget:
+
+```typescript
+thinking: {
+  budget: 32000,  // For complex architecture decisions
+}
+```
+
+Recommended budgets:
+- Simple tasks: 8000-16000
+- Complex reasoning: 32000
+- Strategic planning: 32000+
+
+### 5. Tool Restrictions Match Role
+
+If agent is "read-only", enforce it:
+- No `write`, `edit` tools
+- No `delegate_task` (prevent recursion)
+- Consider allowlist for maximum safety
+
+### 6. Meaningful Metadata
+
+Good metadata helps Sisyphus delegate correctly:
+
+```typescript
+// ✅ Specific and actionable
+triggers: [
+  { domain: "TypeScript types", trigger: "Complex generic patterns" }
+]
+
+// ❌ Vague and unhelpful
+triggers: [
+  { domain: "Code", trigger: "When needed" }
+]
+```
+
+---
+
+## Example: Complete Agent Implementation
+
+See `src/agents/oracle.ts` for a production example:
+
+```typescript
+// Simplified Oracle implementation
+import type { AgentConfig } from "@opencode-ai/sdk"
+import type { AgentFactory, AgentPromptMetadata } from "./types"
+
+const ORACLE_SYSTEM_PROMPT = `
+You are Oracle - a read-only high-IQ consultant for debugging and architecture.
+
+## Your Role
+- Provide strategic advice on architecture decisions
+- Help debug complex issues after multiple failed attempts
+- Review code and suggest improvements
+
+## Constraints
+- You are READ-ONLY. You cannot modify any files.
+- Do not attempt to fix bugs directly - advise only.
+- Be concise and actionable.
+`
+
+export function createOracleAgent(model: string): AgentConfig {
+  return {
+    name: "oracle",
+    description: "Read-only consultation for architecture and debugging",
+    model,
+    prompt: ORACLE_SYSTEM_PROMPT,
+    temperature: 0.1,
+    thinking: { budget: 32000 },
+  }
+}
+
+createOracleAgent.mode = "subagent" as const
+
+export const ORACLE_PROMPT_METADATA: AgentPromptMetadata = {
+  category: "advisor",
+  cost: "EXPENSIVE",
+  triggers: [
+    { domain: "Architecture decisions", trigger: "Multi-system tradeoffs" },
+    { domain: "Hard debugging", trigger: "After 2+ failed fix attempts" },
+  ],
+  useWhen: [
+    "Complex architecture design",
+    "2+ failed fix attempts",
+    "Unfamiliar code patterns",
+  ],
+  avoidWhen: [
+    "Simple file operations",
+    "First attempt at any fix",
+    "Trivial decisions",
+  ],
+}
+```
+
+---
+
+## Next Steps
+
+- [02-hook-system.md](./02-hook-system.md) - Adding lifecycle hooks
+- [04-delegation-orchestration.md](./04-delegation-orchestration.md) - How delegation works

--- a/docs/developer-guide/02-hook-system.md
+++ b/docs/developer-guide/02-hook-system.md
@@ -1,0 +1,677 @@
+# Hook System Guide
+
+This guide explains how the hook system works and how to add new hooks to oh-my-opencode.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Hook Events](#hook-events)
+- [Hook Execution Order](#hook-execution-order)
+- [Creating a New Hook](#creating-a-new-hook)
+- [Hook Patterns](#hook-patterns)
+- [Registration Process](#registration-process)
+- [Performance Considerations](#performance-considerations)
+- [Best Practices](#best-practices)
+
+---
+
+## Overview
+
+Hooks are **lifecycle interceptors** that can modify, block, or react to agent behavior at specific points in the execution flow.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Hook Execution Flow                         │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  User Message                                                   │
+│       │                                                         │
+│       ▼                                                         │
+│  ┌─────────────────────┐                                       │
+│  │ UserPromptSubmit    │ ← Can BLOCK, modify, detect keywords  │
+│  │ (chat.message)      │                                       │
+│  └─────────────────────┘                                       │
+│       │                                                         │
+│       ▼                                                         │
+│  Agent Processing...                                            │
+│       │                                                         │
+│       ▼                                                         │
+│  ┌─────────────────────┐                                       │
+│  │ PreToolUse          │ ← Can BLOCK, validate, inject context │
+│  │ (tool.execute.before)│                                       │
+│  └─────────────────────┘                                       │
+│       │                                                         │
+│       ▼                                                         │
+│  Tool Execution                                                 │
+│       │                                                         │
+│       ▼                                                         │
+│  ┌─────────────────────┐                                       │
+│  │ PostToolUse         │ ← Cannot block, transform output      │
+│  │ (tool.execute.after)│                                       │
+│  └─────────────────────┘                                       │
+│       │                                                         │
+│       ▼                                                         │
+│  Agent continues or stops...                                    │
+│       │                                                         │
+│       ▼                                                         │
+│  ┌─────────────────────┐                                       │
+│  │ Stop                │ ← Cannot block, cleanup, continue     │
+│  │ (event: session.stop)│                                       │
+│  └─────────────────────┘                                       │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Hook Events
+
+### Available Events
+
+| Event | OpenCode Hook | Can Block | Typical Use Cases |
+|-------|---------------|-----------|-------------------|
+| `UserPromptSubmit` | `chat.message` | Yes | Keyword detection, slash commands, context injection |
+| `PreToolUse` | `tool.execute.before` | Yes | Validate inputs, inject context, modify tool args |
+| `PostToolUse` | `tool.execute.after` | No | Transform output, truncate, error recovery |
+| `Stop` | `event` (session.stop) | No | Auto-continue, notifications, cleanup |
+| `onSummarize` | Compaction | No | Preserve state, inject summary context |
+| `MessagesTransform` | `chat.messages.transform` | No | Modify message history before sending |
+| `ChatParams` | `chat.params` | No | Modify model parameters |
+
+### Event Signatures
+
+```typescript
+// UserPromptSubmit (chat.message)
+type ChatMessageHook = (
+  input: { messages: Message[] },
+  output: { response?: string }
+) => Promise<void>
+
+// PreToolUse (tool.execute.before)
+type PreToolUseHook = (
+  input: { tool: string; input: unknown },
+  output: { block?: boolean; error?: string }
+) => Promise<void>
+
+// PostToolUse (tool.execute.after)
+type PostToolUseHook = (
+  input: { tool: string; input: unknown },
+  output: { output: string }
+) => Promise<void>
+
+// Stop (event)
+type EventHook = (
+  { event }: { event: { type: string; properties?: unknown } }
+) => Promise<void>
+
+// MessagesTransform
+type MessagesTransformHook = (
+  output: { messages: Message[] }
+) => Promise<void>
+```
+
+---
+
+## Hook Execution Order
+
+### UserPromptSubmit Hooks
+
+```
+User sends message
+     │
+     ├─→ keywordDetector      (detects ultrawork, search, etc.)
+     ├─→ claudeCodeHooks      (Claude Code settings.json compat)
+     ├─→ autoSlashCommand     (detects /command patterns)
+     └─→ startWork            (Sisyphus work session)
+```
+
+### PreToolUse Hooks
+
+```
+Tool about to execute
+     │
+     ├─→ subagentQuestionBlocker   (blocks question tool in subagents)
+     ├─→ questionLabelTruncator    (truncates question labels)
+     ├─→ claudeCodeHooks           (Claude Code compat)
+     ├─→ nonInteractiveEnv         (non-TTY handling)
+     ├─→ commentChecker            (validates comments)
+     ├─→ directoryAgentsInjector   (injects AGENTS.md)
+     ├─→ directoryReadmeInjector   (injects README.md)
+     ├─→ rulesInjector             (conditional rules)
+     ├─→ prometheusMdOnly          (planner read-only)
+     ├─→ sisyphusJuniorNotepad     (notepad injection)
+     └─→ atlasHook                 (orchestration)
+```
+
+### PostToolUse Hooks
+
+```
+Tool completed
+     │
+     ├─→ claudeCodeHooks           (Claude Code compat)
+     ├─→ toolOutputTruncator       (truncates large outputs)
+     ├─→ contextWindowMonitor      (warns on low headroom)
+     ├─→ commentChecker            (validates comments)
+     ├─→ directoryAgentsInjector   (marks injected)
+     ├─→ directoryReadmeInjector   (marks injected)
+     ├─→ rulesInjector             (tracks rules)
+     ├─→ emptyTaskResponseDetector (detects empty responses)
+     ├─→ agentUsageReminder        (reminds of agents)
+     ├─→ interactiveBashSession    (tmux session)
+     ├─→ editErrorRecovery         (recovers from edit failures)
+     ├─→ delegateTaskRetry         (retries failed delegations)
+     ├─→ atlasHook                 (orchestration)
+     └─→ taskResumeInfo            (resume info)
+```
+
+---
+
+## Creating a New Hook
+
+### Step 1: Create Hook Directory
+
+Create `src/hooks/my-hook/index.ts`:
+
+```typescript
+import type { PluginInput } from "@opencode-ai/plugin"
+
+export interface MyHookOptions {
+  // Optional configuration
+  enabled?: boolean
+  threshold?: number
+}
+
+export function createMyHook(ctx: PluginInput, options?: MyHookOptions) {
+  // Hook-scoped state (persists across calls)
+  const state = new Map<string, unknown>()
+  
+  return {
+    // PostToolUse hook - runs after tool execution
+    "tool.execute.after": async (
+      input: { tool: string; input: unknown },
+      output: { output: string }
+    ) => {
+      // Only process specific tools
+      if (input.tool !== "edit" && input.tool !== "write") {
+        return
+      }
+      
+      // Modify output (append, don't replace)
+      output.output += "\n\n[My Hook]: Processing complete."
+    },
+    
+    // PreToolUse hook - runs before tool execution
+    "tool.execute.before": async (
+      input: { tool: string; input: unknown },
+      output: { block?: boolean; error?: string }
+    ) => {
+      // Example: block dangerous operations
+      if (input.tool === "bash") {
+        const cmd = (input.input as { command?: string })?.command
+        if (cmd?.includes("rm -rf /")) {
+          output.block = true
+          output.error = "Dangerous command blocked"
+        }
+      }
+    },
+    
+    // Event hook - cleanup on session stop
+    "event": async ({ event }: { event: { type: string } }) => {
+      if (event.type === "session.stop") {
+        // Cleanup state for this session
+        state.clear()
+      }
+    },
+  }
+}
+```
+
+### Step 2: Add to Config Schema
+
+Edit `src/config/schema.ts`:
+
+```typescript
+export const HookNameSchema = z.enum([
+  // ... existing hooks
+  "my-hook",  // Add your hook
+])
+
+export type HookName = z.infer<typeof HookNameSchema>
+```
+
+### Step 3: Register in Plugin Entry
+
+Edit `src/index.ts`:
+
+```typescript
+import { createMyHook } from "./hooks/my-hook"
+
+// In OhMyOpenCodePlugin function:
+const myHook = isHookEnabled("my-hook")
+  ? createMyHook(ctx, { threshold: 100 })
+  : null
+
+// Return hook handlers
+return {
+  // ...
+  
+  "tool.execute.after": async (input, output) => {
+    // ... existing hooks
+    await myHook?.["tool.execute.after"]?.(input, output)
+  },
+  
+  "tool.execute.before": async (input, output) => {
+    // ... existing hooks
+    await myHook?.["tool.execute.before"]?.(input, output)
+  },
+  
+  "event": async (eventInput) => {
+    // ... existing hooks
+    await myHook?.["event"]?.(eventInput)
+  },
+}
+```
+
+### Step 4: Export from Index
+
+Edit `src/hooks/index.ts`:
+
+```typescript
+export { createMyHook } from "./my-hook"
+```
+
+---
+
+## Hook Patterns
+
+### Pattern 1: Simple Single-Event Hook
+
+For hooks that only handle one event type:
+
+```typescript
+export function createToolOutputTruncatorHook(ctx: PluginInput) {
+  const MAX_OUTPUT = 50000
+  
+  return {
+    "tool.execute.after": async (
+      input: { tool: string; input: unknown },
+      output: { output: string }
+    ) => {
+      if (output.output.length > MAX_OUTPUT) {
+        output.output = output.output.slice(0, MAX_OUTPUT) + "\n[TRUNCATED]"
+      }
+    },
+  }
+}
+```
+
+### Pattern 2: Multi-Event with Shared State
+
+For hooks that need state across events:
+
+```typescript
+interface SessionState {
+  injectedFiles: Set<string>
+  tokenCount: number
+}
+
+export function createContextInjectorHook(ctx: PluginInput) {
+  // State per session
+  const sessions = new Map<string, SessionState>()
+  
+  const getState = (sessionID: string): SessionState => {
+    if (!sessions.has(sessionID)) {
+      sessions.set(sessionID, {
+        injectedFiles: new Set(),
+        tokenCount: 0,
+      })
+    }
+    return sessions.get(sessionID)!
+  }
+  
+  return {
+    "tool.execute.before": async (input, output) => {
+      const sessionID = extractSessionID(input)
+      const state = getState(sessionID)
+      
+      // Track injected files to avoid duplicates
+      if (state.injectedFiles.has("AGENTS.md")) {
+        return
+      }
+      
+      // ... inject content
+      state.injectedFiles.add("AGENTS.md")
+    },
+    
+    "event": async ({ event }) => {
+      if (event.type === "session.deleted") {
+        const sessionID = event.properties?.sessionID
+        if (sessionID) {
+          sessions.delete(sessionID)
+        }
+      }
+    },
+  }
+}
+```
+
+### Pattern 3: Blocking Hook
+
+For hooks that can prevent tool execution:
+
+```typescript
+export function createCommentCheckerHook(config?: CommentCheckerConfig) {
+  return {
+    "tool.execute.before": async (
+      input: { tool: string; input: unknown },
+      output: { block?: boolean; error?: string }
+    ) => {
+      if (input.tool !== "edit" && input.tool !== "write") {
+        return
+      }
+      
+      const content = extractContent(input)
+      const commentRatio = calculateCommentRatio(content)
+      
+      if (commentRatio > 0.3) {
+        output.block = true
+        output.error = `Too many comments (${Math.round(commentRatio * 100)}%). Reduce comment density and try again.`
+      }
+    },
+  }
+}
+```
+
+### Pattern 4: Auto-Continue Hook
+
+For hooks that trigger continuation:
+
+```typescript
+export function createTodoContinuationEnforcer(ctx: PluginInput) {
+  return {
+    "event": async ({ event }) => {
+      if (event.type !== "session.stop") return
+      
+      const sessionID = event.properties?.sessionID
+      const hasPendingTodos = await checkPendingTodos(sessionID)
+      
+      if (hasPendingTodos) {
+        // Inject continuation reminder
+        await ctx.client.session.prompt({
+          path: { id: sessionID },
+          body: {
+            parts: [{
+              type: "text",
+              text: "[SYSTEM REMINDER] Incomplete tasks remain. Continue working."
+            }],
+          },
+        })
+      }
+    },
+  }
+}
+```
+
+---
+
+## Registration Process
+
+### Complete Checklist
+
+When adding a new hook:
+
+- [ ] Create `src/hooks/my-hook/index.ts` with factory function
+- [ ] Add hook name to `HookNameSchema` in `src/config/schema.ts`
+- [ ] Import hook in `src/index.ts`
+- [ ] Create hook instance with `isHookEnabled()` check
+- [ ] Add to appropriate event handlers in return object
+- [ ] Export from `src/hooks/index.ts`
+- [ ] Run `bun run build:schema`
+- [ ] Run `bun run build`
+- [ ] Test hook behavior
+
+### Hook Execution Integration
+
+In `src/index.ts`, hooks are integrated into the returned plugin object:
+
+```typescript
+return {
+  // Tool execution hooks
+  "tool.execute.before": async (input, output) => {
+    // Execute hooks in order
+    await hook1?.["tool.execute.before"]?.(input, output)
+    await hook2?.["tool.execute.before"]?.(input, output)
+    // Your hook
+    await myHook?.["tool.execute.before"]?.(input, output)
+  },
+  
+  "tool.execute.after": async (input, output) => {
+    await hook1?.["tool.execute.after"]?.(input, output)
+    await hook2?.["tool.execute.after"]?.(input, output)
+    await myHook?.["tool.execute.after"]?.(input, output)
+  },
+  
+  // Chat hooks
+  "chat.message": async (input, output) => {
+    await chatHook1?.(input, output)
+    await chatHook2?.(input, output)
+  },
+  
+  // Event hooks
+  "event": async (eventInput) => {
+    await eventHook1?.(eventInput)
+    await eventHook2?.(eventInput)
+  },
+}
+```
+
+---
+
+## Performance Considerations
+
+### PreToolUse is Critical
+
+`PreToolUse` hooks run on **EVERY tool call**. Keep them fast:
+
+```typescript
+// ❌ BAD: Heavy computation in PreToolUse
+"tool.execute.before": async (input, output) => {
+  const analysis = await heavyAnalysis(input)  // Slow!
+  // ...
+}
+
+// ✅ GOOD: Quick checks only
+"tool.execute.before": async (input, output) => {
+  if (input.tool !== "edit") return  // Early exit
+  // Quick validation only
+}
+```
+
+### Memory Management
+
+Clean up state on session end:
+
+```typescript
+"event": async ({ event }) => {
+  if (event.type === "session.deleted") {
+    const sessionID = event.properties?.sessionID
+    sessionState.delete(sessionID)  // Prevent memory leaks
+  }
+}
+```
+
+### Avoid Redundant Work
+
+Track what you've already done:
+
+```typescript
+const injectedSessions = new Set<string>()
+
+"tool.execute.before": async (input, output) => {
+  const sessionID = getSessionID(input)
+  
+  // Skip if already injected
+  if (injectedSessions.has(sessionID)) {
+    return
+  }
+  
+  // Do work...
+  injectedSessions.add(sessionID)
+}
+```
+
+---
+
+## Best Practices
+
+### 1. Use Early Returns
+
+```typescript
+"tool.execute.after": async (input, output) => {
+  // Skip irrelevant tools immediately
+  if (input.tool !== "edit" && input.tool !== "write") {
+    return
+  }
+  
+  // Process only relevant tools
+}
+```
+
+### 2. Append, Don't Replace
+
+```typescript
+// ❌ BAD: Replaces entire output
+output.output = "My message"
+
+// ✅ GOOD: Appends to existing output
+output.output += "\n\n[My Hook]: Additional info"
+```
+
+### 3. Handle Errors Gracefully
+
+```typescript
+"tool.execute.after": async (input, output) => {
+  try {
+    await riskyOperation()
+  } catch (error) {
+    // Log but don't crash
+    console.error("[MyHook] Error:", error)
+    // Optionally append warning
+    output.output += "\n\n[Warning]: Hook processing failed"
+  }
+}
+```
+
+### 4. Make Hooks Configurable
+
+```typescript
+export interface MyHookConfig {
+  enabled?: boolean
+  maxLength?: number
+  blockedPatterns?: string[]
+}
+
+export function createMyHook(ctx: PluginInput, config?: MyHookConfig) {
+  const maxLength = config?.maxLength ?? 10000
+  const patterns = config?.blockedPatterns ?? []
+  
+  // Use config values...
+}
+```
+
+### 5. Document Hook Behavior
+
+```typescript
+/**
+ * Comment Checker Hook
+ * 
+ * Prevents excessive comments in generated code.
+ * 
+ * Events:
+ * - PreToolUse: Blocks edit/write if comment ratio > 30%
+ * - PostToolUse: Warns if comment ratio > 20%
+ * 
+ * Config:
+ * - threshold: Maximum allowed comment ratio (default: 0.3)
+ */
+export function createCommentCheckerHook(config?: CommentCheckerConfig) {
+  // ...
+}
+```
+
+---
+
+## Example: Complete Hook Implementation
+
+See `src/hooks/comment-checker/` for a production example:
+
+```typescript
+// src/hooks/comment-checker/index.ts
+import type { PluginInput } from "@opencode-ai/plugin"
+import { CommentChecker } from "@code-yeongyu/comment-checker"
+
+export interface CommentCheckerConfig {
+  threshold?: number
+  warnOnly?: boolean
+}
+
+export function createCommentCheckerHooks(config?: CommentCheckerConfig) {
+  const threshold = config?.threshold ?? 0.3
+  const warnOnly = config?.warnOnly ?? false
+  const checker = new CommentChecker()
+  
+  return {
+    "tool.execute.before": async (
+      input: { tool: string; input: unknown },
+      output: { block?: boolean; error?: string }
+    ) => {
+      // Only check edit/write tools
+      if (input.tool !== "edit" && input.tool !== "write") {
+        return
+      }
+      
+      const content = extractContent(input)
+      if (!content) return
+      
+      const ratio = checker.getCommentRatio(content)
+      
+      if (ratio > threshold && !warnOnly) {
+        output.block = true
+        output.error = `Comment density too high (${Math.round(ratio * 100)}%). ` +
+          `Maximum allowed: ${Math.round(threshold * 100)}%. ` +
+          `Remove excessive comments and try again.`
+      }
+    },
+    
+    "tool.execute.after": async (
+      input: { tool: string; input: unknown },
+      output: { output: string }
+    ) => {
+      if (input.tool !== "edit" && input.tool !== "write") {
+        return
+      }
+      
+      const content = extractContent(input)
+      if (!content) return
+      
+      const ratio = checker.getCommentRatio(content)
+      
+      if (ratio > threshold * 0.7) {
+        output.output += `\n\n[Comment Checker Warning] Comment density: ${Math.round(ratio * 100)}%`
+      }
+    },
+  }
+}
+
+function extractContent(input: unknown): string | null {
+  const typedInput = input as { input?: { content?: string; newString?: string } }
+  return typedInput?.input?.content ?? typedInput?.input?.newString ?? null
+}
+```
+
+---
+
+## Next Steps
+
+- [03-tool-system.md](./03-tool-system.md) - Adding tools
+- [04-delegation-orchestration.md](./04-delegation-orchestration.md) - How orchestration works

--- a/docs/developer-guide/03-tool-system.md
+++ b/docs/developer-guide/03-tool-system.md
@@ -1,0 +1,632 @@
+# Tool System Guide
+
+This guide explains how the tool system works and how to add new tools to oh-my-opencode.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Tool Architecture](#tool-architecture)
+- [Tool Patterns](#tool-patterns)
+- [Creating a New Tool](#creating-a-new-tool)
+- [Tool Categories](#tool-categories)
+- [Registration Process](#registration-process)
+- [Best Practices](#best-practices)
+
+---
+
+## Overview
+
+Tools are **capabilities** that agents can invoke to interact with the system. oh-my-opencode provides 20+ tools across 7 categories.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      Tool Categories                            │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐             │
+│  │    LSP      │  │  AST-Grep   │  │   Search    │             │
+│  │ (6 tools)   │  │ (2 tools)   │  │ (2 tools)   │             │
+│  │             │  │             │  │             │             │
+│  │ definition  │  │ search      │  │ grep        │             │
+│  │ references  │  │ replace     │  │ glob        │             │
+│  │ symbols     │  │             │  │             │             │
+│  │ diagnostics │  │             │  │             │             │
+│  │ rename      │  │             │  │             │             │
+│  └─────────────┘  └─────────────┘  └─────────────┘             │
+│                                                                 │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐             │
+│  │   Session   │  │    Agent    │  │ Background  │             │
+│  │ (4 tools)   │  │ (2 tools)   │  │ (2 tools)   │             │
+│  │             │  │             │  │             │             │
+│  │ list        │  │ delegate    │  │ output      │             │
+│  │ read        │  │ call_omo    │  │ cancel      │             │
+│  │ search      │  │             │  │             │             │
+│  │ info        │  │             │  │             │             │
+│  └─────────────┘  └─────────────┘  └─────────────┘             │
+│                                                                 │
+│  ┌─────────────┐  ┌─────────────┐                              │
+│  │   Skill     │  │   System    │                              │
+│  │ (3 tools)   │  │ (2 tools)   │                              │
+│  │             │  │             │                              │
+│  │ skill       │  │ interactive │                              │
+│  │ skill_mcp   │  │ look_at     │                              │
+│  │ slashcommand│  │             │                              │
+│  └─────────────┘  └─────────────┘                              │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Tool Architecture
+
+### Core Types
+
+```typescript
+// From @opencode-ai/plugin
+interface ToolDefinition {
+  description: string
+  args: Record<string, ArgSchema>
+  execute: (args: unknown, context: ToolContext) => Promise<string>
+}
+
+interface ArgSchema {
+  // Zod-like schema definition
+  type: "string" | "number" | "boolean" | "array" | "object"
+  description?: string
+  optional?: boolean
+}
+
+interface ToolContext {
+  sessionID: string
+  directory: string
+  // ... other context
+}
+```
+
+### Two Patterns
+
+| Pattern | When to Use | Example |
+|---------|-------------|---------|
+| **Direct ToolDefinition** | Static tools without runtime dependencies | grep, glob, LSP tools |
+| **Factory Function** | Tools needing context, config, or managers | delegate_task, background tools |
+
+---
+
+## Tool Patterns
+
+### Pattern 1: Direct ToolDefinition (Static)
+
+For simple tools that don't need runtime context:
+
+```typescript
+// src/tools/grep/tools.ts
+import { tool, type ToolDefinition } from "@opencode-ai/plugin"
+
+export const grep: ToolDefinition = tool({
+  description: "Search file contents using regex patterns",
+  
+  args: {
+    pattern: tool.schema.string().describe("Regex pattern to search"),
+    path: tool.schema.string().optional().describe("Directory to search"),
+    include: tool.schema.string().optional().describe("File pattern filter"),
+  },
+  
+  async execute(args) {
+    const { pattern, path, include } = args as {
+      pattern: string
+      path?: string
+      include?: string
+    }
+    
+    // Implementation
+    const results = await searchFiles(pattern, path, include)
+    return formatResults(results)
+  },
+})
+```
+
+### Pattern 2: Factory Function (Context-Dependent)
+
+For tools that need runtime context or shared managers:
+
+```typescript
+// src/tools/delegate-task/tools.ts
+import { tool, type ToolDefinition } from "@opencode-ai/plugin"
+import type { BackgroundManager } from "../../features/background-agent"
+
+export interface DelegateTaskOptions {
+  manager: BackgroundManager
+  client: OpenCodeClient
+  directory: string
+  userCategories?: Record<string, CategoryConfig>
+}
+
+export function createDelegateTask(options: DelegateTaskOptions): ToolDefinition {
+  const { manager, client, directory, userCategories } = options
+  
+  return tool({
+    description: "Spawn agent task with category-based delegation",
+    
+    args: {
+      prompt: tool.schema.string().describe("Task prompt"),
+      category: tool.schema.string().optional().describe("Task category"),
+      subagent_type: tool.schema.string().optional().describe("Agent type"),
+      run_in_background: tool.schema.boolean().describe("Async execution"),
+      load_skills: tool.schema.array(tool.schema.string()).describe("Skills to load"),
+    },
+    
+    async execute(args, context) {
+      // Can use options (manager, client, etc.)
+      const task = await manager.launch({
+        prompt: args.prompt,
+        category: args.category,
+        // ...
+      })
+      
+      return `Task launched: ${task.id}`
+    },
+  })
+}
+```
+
+---
+
+## Creating a New Tool
+
+### Step 1: Create Tool Directory
+
+Create `src/tools/my-tool/`:
+
+```
+my-tool/
+├── index.ts      # Barrel export
+├── tools.ts      # Tool implementation
+├── types.ts      # Type definitions
+└── constants.ts  # Constants (optional)
+```
+
+### Step 2: Define Types
+
+`src/tools/my-tool/types.ts`:
+
+```typescript
+import { z } from "zod"
+
+// Input validation schema
+export const MyToolArgsSchema = z.object({
+  input: z.string().describe("Input value"),
+  options: z.object({
+    flag: z.boolean().optional(),
+    limit: z.number().optional(),
+  }).optional(),
+})
+
+export type MyToolArgs = z.infer<typeof MyToolArgsSchema>
+
+// Output types
+export interface MyToolResult {
+  success: boolean
+  data: unknown
+  message: string
+}
+```
+
+### Step 3: Implement the Tool
+
+`src/tools/my-tool/tools.ts`:
+
+```typescript
+import { tool, type ToolDefinition } from "@opencode-ai/plugin"
+import type { MyToolArgs } from "./types"
+
+// Direct ToolDefinition pattern
+export const my_tool: ToolDefinition = tool({
+  description: `
+    Brief description of what this tool does.
+    
+    Usage notes:
+    - When to use this tool
+    - What it returns
+    - Important considerations
+  `,
+  
+  args: {
+    input: tool.schema.string().describe("The input to process"),
+    options: tool.schema.object({
+      flag: tool.schema.boolean().optional().describe("Enable feature X"),
+      limit: tool.schema.number().optional().describe("Maximum results"),
+    }).optional().describe("Tool options"),
+  },
+  
+  async execute(args) {
+    const { input, options } = args as MyToolArgs
+    
+    try {
+      // Implementation
+      const result = await processInput(input, options)
+      
+      // Return string (required)
+      return JSON.stringify(result, null, 2)
+    } catch (error) {
+      // Error handling
+      const message = error instanceof Error ? error.message : String(error)
+      return `Error: ${message}`
+    }
+  },
+})
+
+// OR: Factory pattern
+export function createMyTool(config: MyToolConfig): ToolDefinition {
+  return tool({
+    description: "...",
+    args: { /* ... */ },
+    async execute(args, context) {
+      // Can use config and context
+      return "result"
+    },
+  })
+}
+```
+
+### Step 4: Create Barrel Export
+
+`src/tools/my-tool/index.ts`:
+
+```typescript
+export { my_tool } from "./tools"
+export type { MyToolArgs, MyToolResult } from "./types"
+```
+
+### Step 5: Register the Tool
+
+Edit `src/tools/index.ts`:
+
+```typescript
+import { my_tool } from "./my-tool"
+
+// For static tools
+export const builtinTools: Record<string, ToolDefinition> = {
+  // ... existing tools
+  my_tool,
+}
+
+// For factory tools, export separately
+export { createMyTool } from "./my-tool"
+```
+
+### Step 6: Add to Plugin (Factory Only)
+
+For factory tools, update `src/index.ts`:
+
+```typescript
+import { createMyTool } from "./tools"
+
+// In OhMyOpenCodePlugin:
+const myTool = createMyTool({
+  // config
+})
+
+return {
+  tool: {
+    ...builtinTools,
+    my_tool: myTool,  // Add factory tool
+  },
+  // ...
+}
+```
+
+---
+
+## Tool Categories
+
+### LSP Tools
+
+Language Server Protocol integration:
+
+| Tool | Purpose |
+|------|---------|
+| `lsp_goto_definition` | Jump to symbol definition |
+| `lsp_find_references` | Find all usages of symbol |
+| `lsp_symbols` | Get document/workspace symbols |
+| `lsp_diagnostics` | Get errors/warnings |
+| `lsp_prepare_rename` | Check if rename is valid |
+| `lsp_rename` | Rename symbol across workspace |
+
+### AST-Grep Tools
+
+AST-aware code search and replace:
+
+| Tool | Purpose |
+|------|---------|
+| `ast_grep_search` | Search code patterns (25 languages) |
+| `ast_grep_replace` | Replace code patterns (dry-run by default) |
+
+### Search Tools
+
+File and content search:
+
+| Tool | Purpose |
+|------|---------|
+| `grep` | Regex content search (60s timeout, 10MB limit) |
+| `glob` | File pattern matching (100 file limit) |
+
+### Session Tools
+
+Session management:
+
+| Tool | Purpose |
+|------|---------|
+| `session_list` | List all sessions |
+| `session_read` | Read session messages |
+| `session_search` | Search session content |
+| `session_info` | Get session metadata |
+
+### Agent Tools
+
+Agent invocation:
+
+| Tool | Purpose |
+|------|---------|
+| `delegate_task` | Category/subagent-based delegation |
+| `call_omo_agent` | Direct agent invocation |
+
+### Background Tools
+
+Background task management:
+
+| Tool | Purpose |
+|------|---------|
+| `background_output` | Get task output |
+| `background_cancel` | Cancel running tasks |
+
+### Skill Tools
+
+Skill system:
+
+| Tool | Purpose |
+|------|---------|
+| `skill` | Load and execute skills |
+| `skill_mcp` | Invoke skill-embedded MCPs |
+| `slashcommand` | Execute slash commands |
+
+---
+
+## Registration Process
+
+### For Static Tools (builtinTools)
+
+```typescript
+// src/tools/index.ts
+export const builtinTools: Record<string, ToolDefinition> = {
+  // Add your tool here
+  my_tool,
+}
+```
+
+These are automatically included in the plugin.
+
+### For Factory Tools
+
+```typescript
+// 1. Export factory from tools/index.ts
+export { createMyTool } from "./my-tool"
+
+// 2. Create instance in src/index.ts
+const myTool = createMyTool(config)
+
+// 3. Add to returned tools
+return {
+  tool: {
+    ...builtinTools,
+    my_tool: myTool,
+  },
+}
+```
+
+### Complete Checklist
+
+- [ ] Create tool directory `src/tools/my-tool/`
+- [ ] Implement `tools.ts` with tool definition
+- [ ] Define types in `types.ts`
+- [ ] Create barrel export `index.ts`
+- [ ] Add to `builtinTools` or export factory
+- [ ] For factory tools, instantiate in `src/index.ts`
+- [ ] Run `bun run build`
+- [ ] Test tool invocation
+
+---
+
+## Best Practices
+
+### 1. Tool Naming
+
+```typescript
+// ✅ Good: snake_case, descriptive
+"lsp_goto_definition"
+"ast_grep_search"
+"session_list"
+
+// ❌ Bad: inconsistent casing
+"goToDefinition"
+"ASTSearch"
+```
+
+### 2. Clear Descriptions
+
+```typescript
+description: `
+  Search file contents using regular expressions.
+  
+  - Supports full regex syntax (e.g., "log.*Error", "function\\s+\\w+")
+  - Filter files by pattern with the include parameter (e.g., "*.js")
+  - Returns file paths with matches sorted by modification time
+  
+  Usage:
+  - Search for patterns: grep(pattern="TODO.*fix", include="*.ts")
+  - Search specific directory: grep(pattern="import", path="src/")
+`,
+```
+
+### 3. Argument Descriptions
+
+```typescript
+args: {
+  // ✅ Good: descriptive, examples
+  pattern: tool.schema.string().describe(
+    "Regex pattern to search (e.g., 'function\\s+\\w+', 'TODO.*')"
+  ),
+  
+  // ❌ Bad: minimal description
+  pattern: tool.schema.string().describe("Pattern"),
+}
+```
+
+### 4. Error Handling
+
+```typescript
+async execute(args) {
+  try {
+    const result = await riskyOperation()
+    return JSON.stringify(result)
+  } catch (error) {
+    // Return error as string, don't throw
+    const message = error instanceof Error ? error.message : String(error)
+    return `Error: ${message}\n\nTry: [suggestion]`
+  }
+}
+```
+
+### 5. Return Format
+
+```typescript
+// ✅ Good: structured, parseable
+return JSON.stringify({
+  success: true,
+  count: results.length,
+  results: results.slice(0, 100),
+}, null, 2)
+
+// ✅ Good: formatted for LLM readability
+return `Found ${results.length} matches:\n\n${formatted}`
+
+// ❌ Bad: raw data dump
+return results.toString()
+```
+
+### 6. Resource Limits
+
+```typescript
+// Set reasonable limits
+const MAX_RESULTS = 100
+const TIMEOUT_MS = 60000
+const MAX_OUTPUT_SIZE = 10 * 1024 * 1024  // 10MB
+
+async execute(args) {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
+  
+  try {
+    const results = await search(args, { signal: controller.signal })
+    return formatResults(results.slice(0, MAX_RESULTS))
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+```
+
+### 7. Context Usage (Factory Pattern)
+
+```typescript
+export function createMyTool(options: Options): ToolDefinition {
+  const { client, directory } = options
+  
+  return tool({
+    async execute(args, context) {
+      // Use options for shared state
+      const cache = options.cache
+      
+      // Use context for request-specific data
+      const sessionID = context.sessionID
+      
+      // ...
+    },
+  })
+}
+```
+
+---
+
+## Example: Complete Tool Implementation
+
+See `src/tools/grep/` for a production example:
+
+```typescript
+// src/tools/grep/tools.ts
+import { tool, type ToolDefinition } from "@opencode-ai/plugin"
+import { execFile } from "node:child_process"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+
+const TIMEOUT_MS = 60000
+const MAX_OUTPUT_SIZE = 10 * 1024 * 1024
+
+export const grep: ToolDefinition = tool({
+  description: `
+    Fast content search tool with safety limits (60s timeout, 10MB output).
+    Searches file contents using regular expressions.
+    Supports full regex syntax (e.g., "log.*Error", "function\\s+\\w+").
+    Filter files by pattern with the include parameter (e.g., "*.js", "*.{ts,tsx}").
+    Returns file paths with matches sorted by modification time.
+  `,
+  
+  args: {
+    pattern: tool.schema.string().describe("Regex pattern to search"),
+    path: tool.schema.string().optional().describe("Directory to search"),
+    include: tool.schema.string().optional().describe("File pattern filter"),
+  },
+  
+  async execute(args) {
+    const { pattern, path, include } = args as {
+      pattern: string
+      path?: string
+      include?: string
+    }
+    
+    const searchPath = path || "."
+    
+    try {
+      const rgArgs = [
+        "--json",
+        "--max-filesize", "1M",
+        pattern,
+        searchPath,
+      ]
+      
+      if (include) {
+        rgArgs.push("--glob", include)
+      }
+      
+      const { stdout } = await execFileAsync("rg", rgArgs, {
+        timeout: TIMEOUT_MS,
+        maxBuffer: MAX_OUTPUT_SIZE,
+      })
+      
+      return formatRipgrepOutput(stdout)
+    } catch (error) {
+      if (error.code === "ENOENT") {
+        return "Error: ripgrep (rg) not found. Please install it."
+      }
+      return `Error: ${error.message}`
+    }
+  },
+})
+```
+
+---
+
+## Next Steps
+
+- [04-delegation-orchestration.md](./04-delegation-orchestration.md) - How delegation works
+- [05-skill-system.md](./05-skill-system.md) - Adding skills

--- a/docs/developer-guide/04-delegation-orchestration.md
+++ b/docs/developer-guide/04-delegation-orchestration.md
@@ -1,0 +1,534 @@
+# Delegation and Orchestration Guide
+
+This guide explains how task delegation and multi-agent orchestration work in oh-my-opencode.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Delegation Architecture](#delegation-architecture)
+- [delegate_task Tool](#delegate_task-tool)
+- [Background Agent Management](#background-agent-management)
+- [Categories System](#categories-system)
+- [Session Continuity](#session-continuity)
+- [Customizing Delegation](#customizing-delegation)
+- [Best Practices](#best-practices)
+
+---
+
+## Overview
+
+oh-my-opencode uses a **multi-agent orchestration** pattern where:
+1. A main agent (Sisyphus/Atlas) receives user requests
+2. Work is delegated to specialized agents based on task type
+3. Background agents run in parallel for efficiency
+4. Results flow back to the orchestrator
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                  Orchestration Flow                             │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  User Request                                                   │
+│       │                                                         │
+│       ▼                                                         │
+│  ┌─────────────────┐                                           │
+│  │   Sisyphus      │  Main Orchestrator                        │
+│  │  (Claude Opus)  │                                           │
+│  └─────────────────┘                                           │
+│       │                                                         │
+│       ├──── delegate_task(category="quick") ─────────────────┐ │
+│       │                      │                                │ │
+│       │                      ▼                                │ │
+│       │              ┌─────────────────┐                      │ │
+│       │              │ Sisyphus-Junior │                      │ │
+│       │              │ (with category  │                      │ │
+│       │              │  model config)  │                      │ │
+│       │              └─────────────────┘                      │ │
+│       │                                                       │ │
+│       ├──── delegate_task(subagent_type="oracle") ──────────┐│ │
+│       │                      │                               ││ │
+│       │                      ▼                               ││ │
+│       │              ┌─────────────────┐                     ││ │
+│       │              │     Oracle      │                     ││ │
+│       │              │   (GPT 5.2)     │                     ││ │
+│       │              └─────────────────┘                     ││ │
+│       │                                                      ││ │
+│       ├──── delegate_task(subagent="explore", bg=true) ─────┼┤ │
+│       │                      │                              ││ │
+│       │                      ▼                              ││ │
+│       │              ┌─────────────────┐                    ││ │
+│       │              │    Explore      │ ← Background       ││ │
+│       │              │ (Grok Code Fast)│                    ││ │
+│       │              └─────────────────┘                    ││ │
+│       │                                                     ││ │
+│       ◄─────────────────────────────────────────────────────┴┴─┤
+│       │                                                        │
+│       ▼                                                        │
+│  Synthesize Results → Response to User                         │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Delegation Architecture
+
+### Two Delegation Modes
+
+| Mode | Command | Spawned Agent | Model Source |
+|------|---------|---------------|--------------|
+| **Category-based** | `delegate_task(category="X")` | Sisyphus-Junior | Category config |
+| **Subagent-based** | `delegate_task(subagent_type="Y")` | Named agent (Oracle, Explore, etc.) | Agent's fallback chain |
+
+### Why Two Modes?
+
+**Category-based**: For generic implementation tasks
+- Uses Sisyphus-Junior (a capable executor)
+- Model/temperature configured per category
+- Best for: "Implement feature X", "Fix bug Y"
+
+**Subagent-based**: For specialized capabilities
+- Uses purpose-built agents (Oracle for consultation, Explore for search)
+- Agent has own optimal model and prompt
+- Best for: Research, debugging consultation, fast search
+
+---
+
+## delegate_task Tool
+
+### API Reference
+
+```typescript
+delegate_task({
+  // REQUIRED
+  prompt: string,           // Task description
+  run_in_background: boolean,  // true=async, false=sync
+  load_skills: string[],    // Skills to inject
+  
+  // MUTUALLY EXCLUSIVE (pick one)
+  category?: string,        // e.g., "quick", "ultrabrain"
+  subagent_type?: string,   // e.g., "oracle", "explore"
+  
+  // OPTIONAL
+  session_id?: string,      // Continue existing session
+  command?: string,         // Command that triggered this
+})
+```
+
+### Usage Examples
+
+```typescript
+// Category-based: Quick fix
+delegate_task({
+  category: "quick",
+  load_skills: ["git-master"],
+  run_in_background: false,
+  prompt: "Fix the typo in README.md line 42",
+})
+
+// Subagent-based: Research
+delegate_task({
+  subagent_type: "explore",
+  load_skills: [],
+  run_in_background: true,
+  prompt: "Find all usages of AuthService in the codebase",
+})
+
+// Subagent-based: Consultation
+delegate_task({
+  subagent_type: "oracle",
+  load_skills: [],
+  run_in_background: false,
+  prompt: "Review my approach: I plan to refactor the auth module...",
+})
+
+// Continue previous session
+delegate_task({
+  session_id: "ses_abc123",
+  prompt: "Fix the type error you mentioned",
+})
+```
+
+---
+
+## Background Agent Management
+
+### BackgroundManager
+
+The `BackgroundManager` class handles async task execution:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                 BackgroundManager Lifecycle                     │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  launch(input)                                                  │
+│       │                                                         │
+│       ▼                                                         │
+│  ┌─────────────┐                                               │
+│  │   PENDING   │  Task created, waiting for slot               │
+│  └─────────────┘                                               │
+│       │                                                         │
+│       ▼ (concurrency slot acquired)                            │
+│  ┌─────────────┐                                               │
+│  │   RUNNING   │  Session created, prompt sent                 │
+│  └─────────────┘                                               │
+│       │                                                         │
+│       │◄──── poll (every 2s) ────────────────────┐             │
+│       │                                          │              │
+│       ▼ (3 consecutive idle polls)               │              │
+│  ┌─────────────┐                                 │              │
+│  │  COMPLETED  │  Task finished                  │              │
+│  └─────────────┘                                 │              │
+│       │                                          │              │
+│       ▼                                          │              │
+│  Release concurrency slot                        │              │
+│  Notify parent session                           │              │
+│                                                  │              │
+│  ──── OR ────                                    │              │
+│                                                  │              │
+│  ┌─────────────┐                                 │              │
+│  │   ERROR     │  Task failed                    │              │
+│  └─────────────┘                                 │              │
+│                                                  │              │
+│  ┌─────────────┐                                 │              │
+│  │  CANCELLED  │  Task cancelled                 │              │
+│  └─────────────┘─────────────────────────────────┘              │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Concurrency Control
+
+```typescript
+// Configuration in oh-my-opencode.json
+{
+  "background_task": {
+    "defaultConcurrency": 5,
+    "providerConcurrency": {
+      "anthropic": 3,
+      "openai": 5,
+      "google": 10
+    },
+    "modelConcurrency": {
+      "anthropic/claude-opus-4-5": 2  // Expensive model limited
+    }
+  }
+}
+```
+
+Priority: `modelConcurrency` > `providerConcurrency` > `defaultConcurrency`
+
+### Task States
+
+| State | Description |
+|-------|-------------|
+| `pending` | In queue, waiting for concurrency slot |
+| `running` | Session active, agent processing |
+| `completed` | Agent finished successfully |
+| `error` | Agent encountered error |
+| `cancelled` | Manually cancelled |
+
+---
+
+## Categories System
+
+### Built-in Categories
+
+| Category | Default Model | Temperature | Use Case |
+|----------|---------------|-------------|----------|
+| `visual-engineering` | Gemini 3 Pro | 0.1 | Frontend, UI/UX, styling |
+| `ultrabrain` | GPT 5.2 Codex | 0.1 | Complex logic, architecture |
+| `deep` | Claude Opus | 0.1 | Goal-oriented problem solving |
+| `artistry` | Gemini 3 Pro | 0.3 | Creative, unconventional approaches |
+| `quick` | Claude Haiku | 0.1 | Simple fixes, typos |
+| `unspecified-low` | Claude Sonnet | 0.1 | General tasks, low effort |
+| `unspecified-high` | Claude Opus | 0.1 | General tasks, high effort |
+| `writing` | Gemini 3 Flash | 0.3 | Documentation, prose |
+
+### Category Configuration
+
+```typescript
+// src/tools/delegate-task/constants.ts
+export const DEFAULT_CATEGORIES: Record<string, CategoryConfig> = {
+  "visual-engineering": {
+    model: "google/gemini-3-pro-preview",
+    temperature: 0.1,
+    description: "Frontend, UI/UX, design, styling, animation",
+  },
+  "ultrabrain": {
+    model: "openai/gpt-5.2-codex",
+    variant: "xhigh",
+    temperature: 0.1,
+    description: "Deep logical reasoning, complex architecture decisions",
+  },
+  // ...
+}
+```
+
+### Custom Categories
+
+Add via config:
+
+```json
+// oh-my-opencode.json
+{
+  "categories": {
+    "my-domain": {
+      "model": "anthropic/claude-sonnet-4-5",
+      "temperature": 0.2,
+      "description": "Domain-specific tasks",
+      "prompt_append": "You are an expert in [domain]. Focus on..."
+    }
+  }
+}
+```
+
+---
+
+## Session Continuity
+
+### Why Session IDs Matter
+
+When you continue with `session_id`:
+- Agent retains FULL conversation context
+- No repeated exploration or setup
+- Saves 70%+ tokens on follow-ups
+- Maintains continuity
+
+```typescript
+// First call - returns session_id in result
+const result1 = await delegate_task({
+  subagent_type: "explore",
+  prompt: "Find auth patterns in codebase",
+  run_in_background: false,
+  load_skills: [],
+})
+// Result includes: session_id: "ses_abc123"
+
+// Continue same session
+const result2 = await delegate_task({
+  session_id: "ses_abc123",  // Continue!
+  prompt: "Also look for JWT usage",
+})
+```
+
+### When to Continue vs New Task
+
+| Scenario | Action |
+|----------|--------|
+| Task failed/incomplete | Continue with `session_id` |
+| Follow-up question | Continue with `session_id` |
+| Multi-turn conversation | Always continue |
+| Completely new topic | New task (no session_id) |
+
+---
+
+## Customizing Delegation
+
+### Adding a Custom Category
+
+1. **Define in config**:
+
+```json
+{
+  "categories": {
+    "backend-api": {
+      "model": "openai/gpt-5.2",
+      "temperature": 0.1,
+      "description": "Backend API development",
+      "prompt_append": "Focus on REST/GraphQL best practices..."
+    }
+  }
+}
+```
+
+2. **Use in delegation**:
+
+```typescript
+delegate_task({
+  category: "backend-api",
+  load_skills: ["typescript-programmer"],
+  prompt: "Implement the user CRUD endpoints",
+  run_in_background: false,
+})
+```
+
+### Modifying Default Categories
+
+Override built-in categories:
+
+```json
+{
+  "categories": {
+    "quick": {
+      "model": "anthropic/claude-sonnet-4-5",  // Override default Haiku
+      "temperature": 0.1
+    }
+  }
+}
+```
+
+### Adding Prompt Injection
+
+Categories can inject additional prompt content:
+
+```json
+{
+  "categories": {
+    "security-focused": {
+      "model": "openai/gpt-5.2",
+      "prompt_append": "Always consider security implications. Check for: injection attacks, auth bypass, data exposure..."
+    }
+  }
+}
+```
+
+---
+
+## Implementation Details
+
+### delegate_task Resolution Flow
+
+```
+delegate_task(args)
+        │
+        ▼
+┌───────────────────────┐
+│  Resolve Skills       │  Load skill content
+└───────────────────────┘
+        │
+        ▼
+┌───────────────────────┐
+│  Resolve Category OR  │
+│  Subagent Type        │
+└───────────────────────┘
+        │
+        ├─── category ──────────────┐
+        │                           ▼
+        │               ┌───────────────────────┐
+        │               │ Get category config   │
+        │               │ (model, temp, prompt) │
+        │               └───────────────────────┘
+        │                           │
+        │                           ▼
+        │               ┌───────────────────────┐
+        │               │ Spawn Sisyphus-Junior │
+        │               │ with category config  │
+        │               └───────────────────────┘
+        │
+        └─── subagent_type ─────────┐
+                                    ▼
+                        ┌───────────────────────┐
+                        │ Resolve agent's model │
+                        │ fallback chain        │
+                        └───────────────────────┘
+                                    │
+                                    ▼
+                        ┌───────────────────────┐
+                        │ Spawn named agent     │
+                        │ (Oracle, Explore...)  │
+                        └───────────────────────┘
+```
+
+### Code Location
+
+Key files for delegation:
+
+```
+src/tools/delegate-task/
+├── tools.ts              # Main delegate_task tool (175 lines)
+├── executor.ts           # Execution logic
+├── categories.ts         # Category resolution
+├── prompt-builder.ts     # System prompt building
+├── constants.ts          # DEFAULT_CATEGORIES
+└── types.ts              # Type definitions
+
+src/features/background-agent/
+├── manager.ts            # BackgroundManager (1418 lines)
+├── concurrency.ts        # ConcurrencyManager
+├── types.ts              # Task types
+└── constants.ts          # Timeouts, polling intervals
+```
+
+---
+
+## Best Practices
+
+### 1. Use Background for Exploration
+
+```typescript
+// ✅ Good: Parallel exploration
+delegate_task({ subagent_type: "explore", run_in_background: true, ... })
+delegate_task({ subagent_type: "explore", run_in_background: true, ... })
+delegate_task({ subagent_type: "librarian", run_in_background: true, ... })
+// Collect results later
+
+// ❌ Bad: Sequential exploration
+await delegate_task({ subagent_type: "explore", run_in_background: false, ... })
+await delegate_task({ subagent_type: "explore", run_in_background: false, ... })
+```
+
+### 2. Match Category to Task
+
+```typescript
+// ✅ Good: Category matches task domain
+delegate_task({ category: "visual-engineering", ... })  // For UI work
+delegate_task({ category: "ultrabrain", ... })          // For complex logic
+delegate_task({ category: "quick", ... })               // For simple fixes
+
+// ❌ Bad: Wrong category
+delegate_task({ category: "quick", prompt: "Design new auth architecture" })
+```
+
+### 3. Load Relevant Skills
+
+```typescript
+// ✅ Good: Skills enhance agent capability
+delegate_task({
+  category: "visual-engineering",
+  load_skills: ["frontend-ui-ux"],  // Relevant skill
+  prompt: "Create a dark mode toggle component",
+})
+
+// ❌ Bad: Missing relevant skills
+delegate_task({
+  category: "visual-engineering",
+  load_skills: [],  // No UI skill loaded
+  prompt: "Create a complex animation system",
+})
+```
+
+### 4. Continue Sessions When Appropriate
+
+```typescript
+// ✅ Good: Continue for follow-ups
+const r1 = await delegate_task({ prompt: "Find X" })
+const r2 = await delegate_task({
+  session_id: r1.session_id,
+  prompt: "Now find Y in same context",
+})
+
+// ❌ Bad: New session for related work
+const r1 = await delegate_task({ prompt: "Find X" })
+const r2 = await delegate_task({ prompt: "Find Y" })  // Lost context!
+```
+
+### 5. Limit Concurrency for Expensive Models
+
+```json
+{
+  "background_task": {
+    "modelConcurrency": {
+      "anthropic/claude-opus-4-5": 2  // Limit expensive model
+    }
+  }
+}
+```
+
+---
+
+## Next Steps
+
+- [05-skill-system.md](./05-skill-system.md) - Adding skills
+- [06-config-system.md](./06-config-system.md) - Configuration system

--- a/docs/developer-guide/05-skill-system.md
+++ b/docs/developer-guide/05-skill-system.md
@@ -1,0 +1,529 @@
+# Skill System
+
+The Skill System provides a mechanism for injecting domain-specific expertise into agents. Unlike Agents (which are autonomous entities) or Tools (which are discrete operations), Skills are **prompt injections** that enhance an agent's capabilities with specialized knowledge, workflows, and constraints.
+
+## Overview
+
+### What is a Skill?
+
+A Skill is a structured prompt template that gets injected into an agent's context when activated. Skills:
+
+- **Inject specialized knowledge** into any agent that loads them
+- **Carry optional MCP configurations** for tool access
+- **Support tool restrictions** to limit agent capabilities when loaded
+- **Can be user-defined or built-in**
+
+### Skills vs Agents vs Tools
+
+| Aspect | Skill | Agent | Tool |
+|--------|-------|-------|------|
+| **Purpose** | Inject expertise/workflow | Autonomous execution | Discrete operation |
+| **Persistence** | Loaded per-task | Runs independently | Called on-demand |
+| **Implementation** | Markdown + YAML frontmatter | TypeScript factory | TypeScript with schema |
+| **Customization** | User-created or built-in | Config-override only | Code-defined |
+| **Example** | `git-master`, `playwright` | `oracle`, `explore` | `delegate_task`, `lsp_rename` |
+
+### Skill Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Skill Loading Pipeline                     │
+├─────────────────────────────────────────────────────────────┤
+│                                                               │
+│  1. Discovery (by priority)                                   │
+│     ┌─────────────────────────────────────────────────────┐ │
+│     │ .opencode/skills/     (project - highest priority)   │ │
+│     │ .claude/skills/       (project - Claude Code compat) │ │
+│     │ ~/.config/opencode/skills/ (user global)             │ │
+│     │ ~/.claude/skills/     (user - Claude Code compat)    │ │
+│     │ Built-in skills       (lowest priority)              │ │
+│     └─────────────────────────────────────────────────────┘ │
+│                                                               │
+│  2. Loading                                                   │
+│     - Parse YAML frontmatter (metadata)                       │
+│     - Extract markdown body (template)                        │
+│     - Load MCP config (from frontmatter or mcp.json)          │
+│     - Resolve allowed tools                                   │
+│                                                               │
+│  3. Injection                                                 │
+│     - Template wrapped in <skill-instruction> tags            │
+│     - $ARGUMENTS placeholder replaced with user input         │
+│     - MCP clients initialized (lazy)                          │
+│                                                               │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Skill Types
+
+### Built-in Skills
+
+Defined in TypeScript, bundled with oh-my-opencode:
+
+| Skill | Description | MCP Config |
+|-------|-------------|------------|
+| `playwright` | Browser automation via Playwright MCP | Yes |
+| `agent-browser` | Browser automation via CLI tool | No |
+| `frontend-ui-ux` | Designer-developer UI/UX expertise | No |
+| `git-master` | Git operations, atomic commits, history search | No |
+| `dev-browser` | Browser automation with persistent state | Yes |
+
+**Location**: `src/features/builtin-skills/skills/`
+
+### User-Defined Skills
+
+Created by users in markdown format with YAML frontmatter:
+
+**Locations** (by priority):
+1. `.opencode/skills/` - Project-specific (highest priority)
+2. `.claude/skills/` - Project-specific (Claude Code compatible)
+3. `~/.config/opencode/skills/` - User global
+4. `~/.claude/skills/` - User global (Claude Code compatible)
+
+## Creating a Skill
+
+### Step 1: Choose Location
+
+```bash
+# Project-specific skill (recommended for project workflows)
+mkdir -p .opencode/skills/my-skill
+
+# User global skill (for personal workflows)
+mkdir -p ~/.config/opencode/skills/my-skill
+```
+
+### Step 2: Create SKILL.md
+
+The skill file must be named either:
+- `SKILL.md` (preferred)
+- `<directory-name>.md` (e.g., `my-skill.md` in `my-skill/` directory)
+
+```markdown
+---
+name: my-skill
+description: "Brief description for skill selection UI. Triggers: 'keyword1', 'keyword2'."
+model: anthropic/claude-sonnet-4-5
+agent: sisyphus-junior
+subtask: true
+argument-hint: "What should I help with?"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+license: MIT
+compatibility: "opencode >= 2.0"
+metadata:
+  author: "Your Name"
+  version: "1.0.0"
+mcp:
+  my-mcp-server:
+    command: npx
+    args:
+      - "@my-org/my-mcp@latest"
+---
+
+# My Skill Name
+
+You are an expert in [domain]. Your role is to [purpose].
+
+## Core Principles
+
+1. **Principle One**: Description
+2. **Principle Two**: Description
+
+## Workflow
+
+When invoked, follow these steps:
+
+1. First, do X
+2. Then, do Y
+3. Finally, do Z
+
+## Examples
+
+### Example 1: Basic Usage
+
+```bash
+# Example command
+my-command --flag value
+```
+
+## Anti-Patterns (NEVER)
+
+- Never do X
+- Never do Y
+
+## User Request
+
+$ARGUMENTS
+```
+
+### Step 3: Frontmatter Reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | No | Skill name (defaults to directory name) |
+| `description` | string | Yes | Shown in skill picker. Include trigger phrases |
+| `model` | string | No | Preferred model for this skill |
+| `agent` | string | No | Preferred agent to run this skill |
+| `subtask` | boolean | No | If `true`, runs as subtask of current session |
+| `argument-hint` | string | No | Placeholder text for argument input |
+| `allowed-tools` | string[] | No | Restrict which tools are available |
+| `license` | string | No | License for the skill |
+| `compatibility` | string | No | Version requirements |
+| `metadata` | object | No | Arbitrary key-value pairs |
+| `mcp` | object | No | MCP server configurations |
+
+### Step 4: Optional MCP Configuration
+
+Skills can include MCP servers in two ways:
+
+**Option A: Frontmatter (inline)**
+
+```yaml
+---
+name: my-skill
+description: "Skill with MCP"
+mcp:
+  my-server:
+    command: npx
+    args:
+      - "@my-org/my-mcp@latest"
+    env:
+      API_KEY: "${MY_API_KEY}"
+---
+```
+
+**Option B: Separate mcp.json file**
+
+Create `mcp.json` in the skill directory:
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "command": "npx",
+      "args": ["@my-org/my-mcp@latest"],
+      "env": {
+        "API_KEY": "${MY_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+The `mcp.json` takes precedence over frontmatter MCP config.
+
+## Skill Loading
+
+### Loading Priority
+
+When multiple skills have the same name, the first one found wins:
+
+```
+1. .opencode/skills/           (opencode-project scope)
+2. .claude/skills/             (project scope)
+3. ~/.config/opencode/skills/  (opencode scope)
+4. ~/.claude/skills/           (user scope)
+5. Built-in skills             (builtin scope)
+```
+
+### Directory Structure Support
+
+Skills support nested directories up to 2 levels deep:
+
+```
+.opencode/skills/
+├── simple-skill/
+│   └── SKILL.md              → name: "simple-skill"
+├── category/
+│   ├── nested-skill/
+│   │   └── SKILL.md          → name: "category/nested-skill"
+│   └── another/
+│       └── SKILL.md          → name: "category/another"
+└── flat-skill.md             → name: "flat-skill"
+```
+
+### Lazy Content Loading
+
+Skills use lazy content loading for efficiency:
+
+```typescript
+interface LazyContentLoader {
+  loaded: boolean
+  content?: string
+  load: () => Promise<string>
+}
+```
+
+The skill body is loaded on first access, not at discovery time.
+
+## Built-in Skill Implementation
+
+### File Structure
+
+```
+src/features/builtin-skills/
+├── skills/
+│   ├── index.ts              # Barrel exports
+│   ├── playwright.ts         # Playwright skill
+│   ├── git-master.ts         # Git operations skill
+│   ├── frontend-ui-ux.ts     # UI/UX skill
+│   └── dev-browser.ts        # Browser automation skill
+├── types.ts                  # BuiltinSkill interface
+├── skills.ts                 # createBuiltinSkills factory
+└── index.ts                  # Public exports
+```
+
+### BuiltinSkill Interface
+
+```typescript
+// src/features/builtin-skills/types.ts
+export interface BuiltinSkill {
+  name: string
+  description: string
+  template: string
+  license?: string
+  compatibility?: string
+  metadata?: Record<string, unknown>
+  allowedTools?: string[]
+  agent?: string
+  model?: string
+  subtask?: boolean
+  argumentHint?: string
+  mcpConfig?: SkillMcpConfig
+}
+```
+
+### Creating a Built-in Skill
+
+```typescript
+// src/features/builtin-skills/skills/my-skill.ts
+import type { BuiltinSkill } from "../types"
+
+export const mySkill: BuiltinSkill = {
+  name: "my-skill",
+  description: "Description shown in skill picker",
+  template: `# My Skill
+
+You are an expert in [domain].
+
+## Instructions
+
+1. Do X
+2. Do Y
+
+## User Request
+
+$ARGUMENTS`,
+  allowedTools: ["Read", "Write", "Edit"],
+  mcpConfig: {
+    "my-mcp": {
+      command: "npx",
+      args: ["@my-org/my-mcp@latest"],
+    },
+  },
+}
+```
+
+### Registering the Skill
+
+```typescript
+// src/features/builtin-skills/skills/index.ts
+export { mySkill } from "./my-skill"
+
+// src/features/builtin-skills/skills.ts
+import { mySkill } from "./skills/index"
+
+export function createBuiltinSkills(options: CreateBuiltinSkillsOptions = {}): BuiltinSkill[] {
+  const { disabledSkills } = options
+  
+  const skills = [
+    browserSkill,
+    frontendUiUxSkill,
+    gitMasterSkill,
+    devBrowserSkill,
+    mySkill,  // Add here
+  ]
+
+  if (!disabledSkills) {
+    return skills
+  }
+
+  return skills.filter((skill) => !disabledSkills.has(skill.name))
+}
+```
+
+## Skill MCP Integration
+
+### How Skill MCPs Work
+
+When a skill with MCP config is loaded:
+
+1. **Discovery**: MCP config extracted from skill
+2. **Lazy Initialization**: MCP client created on first tool call
+3. **Session Scoping**: Each session gets isolated MCP clients
+4. **Cleanup**: Clients cleaned up after 5 minutes idle
+
+### SkillMcpManager
+
+The `SkillMcpManager` handles MCP lifecycle:
+
+```typescript
+// src/features/skill-mcp-manager/types.ts
+export type SkillMcpConfig = Record<string, ClaudeCodeMcpServer>
+
+export interface SkillMcpClientInfo {
+  serverName: string
+  skillName: string
+  sessionID: string
+}
+```
+
+### Invoking Skill MCPs
+
+Use the `skill_mcp` tool to invoke skill-embedded MCPs:
+
+```typescript
+// Tool call
+skill_mcp({
+  mcp_name: "my-mcp",
+  tool_name: "my_tool",
+  arguments: { param: "value" }
+})
+```
+
+## Tool Restrictions
+
+### Allowed Tools
+
+Skills can restrict which tools are available:
+
+```yaml
+---
+name: read-only-skill
+description: "Read-only exploration skill"
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+---
+```
+
+### Tool Pattern Matching
+
+Tool restrictions support patterns:
+
+```yaml
+allowed-tools:
+  - Read              # Exact match
+  - "Bash(git:*)"     # Pattern: any git command
+  - "Bash(npm:*)"     # Pattern: any npm command
+```
+
+## Best Practices
+
+### Skill Design
+
+1. **Single Responsibility**: One skill = one workflow/expertise area
+2. **Clear Triggers**: Include trigger phrases in description
+3. **Structured Output**: Define expected output formats
+4. **Anti-Patterns**: Explicitly list what NOT to do
+5. **Examples**: Include concrete examples
+
+### Skill Template Structure
+
+```markdown
+# [Skill Name]
+
+Brief introduction to the skill's purpose.
+
+---
+
+## Mode Detection (if multiple modes)
+
+| Request Pattern | Mode | Action |
+|-----------------|------|--------|
+| "pattern 1" | MODE_A | Do X |
+| "pattern 2" | MODE_B | Do Y |
+
+---
+
+## Core Principles
+
+1. **Principle**: Description
+2. **Principle**: Description
+
+---
+
+## Workflow
+
+### Phase 1: Setup
+
+Steps...
+
+### Phase 2: Execution
+
+Steps...
+
+### Phase 3: Verification
+
+Steps...
+
+---
+
+## Output Format
+
+```
+EXPECTED OUTPUT FORMAT:
+  field1: value
+  field2: value
+```
+
+---
+
+## Anti-Patterns (NEVER)
+
+| Violation | Why It's Wrong |
+|-----------|----------------|
+| Pattern X | Reason |
+| Pattern Y | Reason |
+
+---
+
+## Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| cmd1 | Does X |
+| cmd2 | Does Y |
+```
+
+### MCP Configuration
+
+1. **Prefer mcp.json**: Easier to maintain than inline YAML
+2. **Use env vars**: `"${VAR_NAME}"` for secrets
+3. **Version lock**: Pin MCP package versions for stability
+
+### Tool Restrictions
+
+1. **Principle of least privilege**: Only allow necessary tools
+2. **Pattern matching**: Use patterns for tool families
+3. **Document restrictions**: Explain why tools are restricted
+
+## File Reference
+
+| File | Purpose |
+|------|---------|
+| `src/features/builtin-skills/skills.ts` | Built-in skill factory |
+| `src/features/builtin-skills/types.ts` | BuiltinSkill interface |
+| `src/features/builtin-skills/skills/*.ts` | Individual skill definitions |
+| `src/features/opencode-skill-loader/loader.ts` | Skill discovery and loading |
+| `src/features/opencode-skill-loader/types.ts` | LoadedSkill, SkillMetadata types |
+| `src/features/skill-mcp-manager/manager.ts` | MCP client lifecycle |
+| `src/features/skill-mcp-manager/types.ts` | SkillMcpConfig types |
+
+## Next Steps
+
+- [06-config-system.md](./06-config-system.md) - Learn about configuration
+- [07-mcp-integration.md](./07-mcp-integration.md) - Understand MCP integration

--- a/docs/developer-guide/06-config-system.md
+++ b/docs/developer-guide/06-config-system.md
@@ -1,0 +1,585 @@
+# Config System
+
+The Config System provides a flexible, type-safe configuration mechanism for oh-my-opencode. It uses Zod schemas for validation, supports JSONC format (JSON with comments), and implements a multi-level configuration hierarchy.
+
+## Overview
+
+### Configuration Hierarchy
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                  Configuration Priority                      │
+├─────────────────────────────────────────────────────────────┤
+│                                                               │
+│  1. Project Config (highest priority)                         │
+│     .opencode/oh-my-opencode.jsonc                           │
+│     .opencode/oh-my-opencode.json                            │
+│                                                               │
+│  2. User Config (base)                                        │
+│     ~/.config/opencode/oh-my-opencode.jsonc                  │
+│     ~/.config/opencode/oh-my-opencode.json                   │
+│                                                               │
+│  Merge Strategy:                                              │
+│     - Arrays: Union (combined, deduplicated)                  │
+│     - Objects: Deep merge (nested keys preserved)             │
+│     - Primitives: Override (project wins)                     │
+│                                                               │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Key Features
+
+- **Zod Schema Validation**: Type-safe config with detailed error messages
+- **JSONC Support**: Comments and trailing commas allowed
+- **Deep Merge**: Nested configurations merged intelligently
+- **Environment Variables**: Secrets injected via `${VAR}` syntax
+- **Auto-Migration**: Legacy config formats upgraded automatically
+
+## Configuration Files
+
+### File Locations
+
+```bash
+# User-level config (applies to all projects)
+~/.config/opencode/oh-my-opencode.jsonc  # Preferred
+~/.config/opencode/oh-my-opencode.json   # Fallback
+
+# Project-level config (overrides user config)
+.opencode/oh-my-opencode.jsonc           # Preferred
+.opencode/oh-my-opencode.json            # Fallback
+```
+
+### JSONC Format
+
+Both `.json` and `.jsonc` are supported. JSONC allows:
+
+```jsonc
+{
+  // Single-line comments
+  "disabled_hooks": [
+    "auto-update-checker",  // Trailing commas OK
+  ],
+  
+  /* Multi-line
+     comments */
+  "agents": {
+    "sisyphus": {
+      "temperature": 0.1  // Inline comments
+    }
+  }
+}
+```
+
+## Schema Structure
+
+### Root Configuration
+
+```typescript
+// src/config/schema.ts
+export const OhMyOpenCodeConfigSchema = z.object({
+  $schema: z.string().optional(),
+  
+  // Feature Toggles
+  new_task_system_enabled: z.boolean().optional(),
+  default_run_agent: z.string().optional(),
+  auto_update: z.boolean().optional(),
+  
+  // Disable Lists
+  disabled_mcps: z.array(AnyMcpNameSchema).optional(),
+  disabled_agents: z.array(BuiltinAgentNameSchema).optional(),
+  disabled_skills: z.array(BuiltinSkillNameSchema).optional(),
+  disabled_hooks: z.array(HookNameSchema).optional(),
+  disabled_commands: z.array(BuiltinCommandNameSchema).optional(),
+  disabled_tools: z.array(z.string()).optional(),
+  
+  // Override Configurations
+  agents: AgentOverridesSchema.optional(),
+  categories: CategoriesConfigSchema.optional(),
+  skills: SkillsConfigSchema.optional(),
+  
+  // Feature Configs
+  claude_code: ClaudeCodeConfigSchema.optional(),
+  sisyphus_agent: SisyphusAgentConfigSchema.optional(),
+  comment_checker: CommentCheckerConfigSchema.optional(),
+  experimental: ExperimentalConfigSchema.optional(),
+  ralph_loop: RalphLoopConfigSchema.optional(),
+  background_task: BackgroundTaskConfigSchema.optional(),
+  notification: NotificationConfigSchema.optional(),
+  babysitting: BabysittingConfigSchema.optional(),
+  git_master: GitMasterConfigSchema.optional(),
+  browser_automation_engine: BrowserAutomationConfigSchema.optional(),
+  websearch: WebsearchConfigSchema.optional(),
+  tmux: TmuxConfigSchema.optional(),
+  sisyphus: SisyphusConfigSchema.optional(),
+})
+```
+
+### Agent Override Schema
+
+Override agent behavior without modifying source code:
+
+```typescript
+export const AgentOverrideConfigSchema = z.object({
+  // Model Configuration
+  model: z.string().optional(),           // Deprecated: use category
+  variant: z.string().optional(),
+  category: z.string().optional(),        // Inherit from category
+  
+  // Generation Parameters
+  temperature: z.number().min(0).max(2).optional(),
+  top_p: z.number().min(0).max(1).optional(),
+  maxTokens: z.number().optional(),
+  
+  // Thinking/Reasoning
+  thinking: z.object({
+    type: z.enum(["enabled", "disabled"]),
+    budgetTokens: z.number().optional(),
+  }).optional(),
+  reasoningEffort: z.enum(["low", "medium", "high", "xhigh"]).optional(),
+  textVerbosity: z.enum(["low", "medium", "high"]).optional(),
+  
+  // Prompt Customization
+  prompt: z.string().optional(),          // Replace system prompt
+  prompt_append: z.string().optional(),   // Append to system prompt
+  skills: z.array(z.string()).optional(), // Inject skills
+  
+  // Tool Configuration
+  tools: z.record(z.string(), z.boolean()).optional(),
+  
+  // Agent Metadata
+  disable: z.boolean().optional(),
+  description: z.string().optional(),
+  mode: z.enum(["subagent", "primary", "all"]).optional(),
+  color: z.string().regex(/^#[0-9A-Fa-f]{6}$/).optional(),
+  
+  // Permissions
+  permission: AgentPermissionSchema.optional(),
+  
+  // Provider Options
+  providerOptions: z.record(z.string(), z.unknown()).optional(),
+})
+```
+
+### Category Schema
+
+Configure delegation categories:
+
+```typescript
+export const CategoryConfigSchema = z.object({
+  description: z.string().optional(),
+  model: z.string().optional(),
+  variant: z.string().optional(),
+  temperature: z.number().min(0).max(2).optional(),
+  top_p: z.number().min(0).max(1).optional(),
+  maxTokens: z.number().optional(),
+  thinking: z.object({
+    type: z.enum(["enabled", "disabled"]),
+    budgetTokens: z.number().optional(),
+  }).optional(),
+  reasoningEffort: z.enum(["low", "medium", "high", "xhigh"]).optional(),
+  textVerbosity: z.enum(["low", "medium", "high"]).optional(),
+  tools: z.record(z.string(), z.boolean()).optional(),
+  prompt_append: z.string().optional(),
+  is_unstable_agent: z.boolean().optional(),
+})
+```
+
+## Configuration Examples
+
+### Basic Configuration
+
+```jsonc
+{
+  "$schema": "./node_modules/oh-my-opencode/schema.json",
+  
+  // Disable features you don't need
+  "disabled_hooks": [
+    "auto-update-checker",
+    "comment-checker"
+  ],
+  
+  // Configure agents
+  "agents": {
+    "sisyphus": {
+      "temperature": 0.1
+    }
+  }
+}
+```
+
+### Agent Customization
+
+```jsonc
+{
+  "agents": {
+    // Override the oracle agent
+    "oracle": {
+      "model": "openai/gpt-5.2",
+      "temperature": 0.2,
+      "thinking": {
+        "type": "enabled",
+        "budgetTokens": 8000
+      },
+      "prompt_append": "\n\nAlways provide code examples.",
+      "skills": ["git-master"]
+    },
+    
+    // Disable the librarian agent
+    "librarian": {
+      "disable": true
+    }
+  }
+}
+```
+
+### Custom Categories
+
+```jsonc
+{
+  "categories": {
+    // Override built-in category
+    "visual-engineering": {
+      "model": "anthropic/claude-sonnet-4-5",
+      "temperature": 0.3,
+      "description": "Frontend and UI/UX work"
+    },
+    
+    // Add custom category
+    "data-pipeline": {
+      "description": "ETL and data processing tasks",
+      "model": "openai/gpt-5.2-codex",
+      "temperature": 0.1,
+      "maxTokens": 16000,
+      "prompt_append": "Focus on efficiency and data integrity."
+    }
+  }
+}
+```
+
+### Background Task Configuration
+
+```jsonc
+{
+  "background_task": {
+    // Global default concurrency
+    "defaultConcurrency": 5,
+    
+    // Per-provider limits
+    "providerConcurrency": {
+      "anthropic": 3,
+      "openai": 5,
+      "google": 2
+    },
+    
+    // Per-model limits (overrides provider)
+    "modelConcurrency": {
+      "anthropic/claude-opus-4-5": 2,
+      "openai/gpt-5.2-codex": 3
+    },
+    
+    // Stale task timeout (3 minutes)
+    "staleTimeoutMs": 180000
+  }
+}
+```
+
+### Claude Code Compatibility
+
+```jsonc
+{
+  "claude_code": {
+    // Enable/disable Claude Code compatibility features
+    "mcp": true,           // Load MCPs from .mcp.json
+    "commands": true,      // Load commands from ~/.claude/commands/
+    "skills": true,        // Load skills from ~/.claude/skills/
+    "agents": true,        // Load agents from ~/.claude/agents/
+    "hooks": true,         // Run Claude Code hooks
+    "plugins": true,       // Load Claude Code plugins
+    
+    // Override specific plugins
+    "plugins_override": {
+      "some-plugin": false  // Disable specific plugin
+    }
+  }
+}
+```
+
+### Experimental Features
+
+```jsonc
+{
+  "experimental": {
+    // Aggressive context truncation
+    "aggressive_truncation": true,
+    
+    // Auto-resume on connection loss
+    "auto_resume": true,
+    
+    // Preemptive context compaction
+    "preemptive_compaction": true,
+    
+    // Truncate all tool outputs
+    "truncate_all_tool_outputs": true,
+    
+    // Dynamic context pruning
+    "dynamic_context_pruning": {
+      "enabled": true,
+      "notification": "detailed",
+      "turn_protection": {
+        "enabled": true,
+        "turns": 3
+      },
+      "protected_tools": ["task", "todowrite"],
+      "strategies": {
+        "deduplication": { "enabled": true },
+        "supersede_writes": { "enabled": true, "aggressive": false },
+        "purge_errors": { "enabled": true, "turns": 5 }
+      }
+    }
+  }
+}
+```
+
+## Config Loading Implementation
+
+### Loading Pipeline
+
+```typescript
+// src/plugin-config.ts
+export function loadPluginConfig(
+  directory: string,
+  ctx: unknown
+): OhMyOpenCodeConfig {
+  // 1. Resolve user config path
+  const configDir = getOpenCodeConfigDir({ binary: "opencode" })
+  const userBasePath = path.join(configDir, "oh-my-opencode")
+  const userDetected = detectConfigFile(userBasePath)
+  const userConfigPath = userDetected.format !== "none"
+    ? userDetected.path
+    : userBasePath + ".json"
+
+  // 2. Resolve project config path
+  const projectBasePath = path.join(directory, ".opencode", "oh-my-opencode")
+  const projectDetected = detectConfigFile(projectBasePath)
+  const projectConfigPath = projectDetected.format !== "none"
+    ? projectDetected.path
+    : projectBasePath + ".json"
+
+  // 3. Load user config (base)
+  let config: OhMyOpenCodeConfig = loadConfigFromPath(userConfigPath, ctx) ?? {}
+
+  // 4. Merge with project config (override)
+  const projectConfig = loadConfigFromPath(projectConfigPath, ctx)
+  if (projectConfig) {
+    config = mergeConfigs(config, projectConfig)
+  }
+
+  return config
+}
+```
+
+### File Detection
+
+```typescript
+// src/shared/jsonc-parser.ts
+export function detectConfigFile(basePath: string): {
+  format: "json" | "jsonc" | "none"
+  path: string
+} {
+  const jsoncPath = `${basePath}.jsonc`
+  const jsonPath = `${basePath}.json`
+
+  if (existsSync(jsoncPath)) {
+    return { format: "jsonc", path: jsoncPath }
+  }
+  if (existsSync(jsonPath)) {
+    return { format: "json", path: jsonPath }
+  }
+  return { format: "none", path: jsonPath }
+}
+```
+
+### JSONC Parsing
+
+```typescript
+// src/shared/jsonc-parser.ts
+import { parse, ParseError, printParseErrorCode } from "jsonc-parser"
+
+export function parseJsonc<T = unknown>(content: string): T {
+  const errors: ParseError[] = []
+  const result = parse(content, errors, {
+    allowTrailingComma: true,
+    disallowComments: false,
+  }) as T
+
+  if (errors.length > 0) {
+    const errorMessages = errors
+      .map((e) => `${printParseErrorCode(e.error)} at offset ${e.offset}`)
+      .join(", ")
+    throw new SyntaxError(`JSONC parse error: ${errorMessages}`)
+  }
+
+  return result
+}
+```
+
+### Config Merging
+
+```typescript
+// src/plugin-config.ts
+export function mergeConfigs(
+  base: OhMyOpenCodeConfig,
+  override: OhMyOpenCodeConfig
+): OhMyOpenCodeConfig {
+  return {
+    ...base,
+    ...override,
+    // Deep merge nested objects
+    agents: deepMerge(base.agents, override.agents),
+    categories: deepMerge(base.categories, override.categories),
+    claude_code: deepMerge(base.claude_code, override.claude_code),
+    
+    // Union arrays (deduplicated)
+    disabled_agents: [
+      ...new Set([
+        ...(base.disabled_agents ?? []),
+        ...(override.disabled_agents ?? []),
+      ]),
+    ],
+    disabled_mcps: [
+      ...new Set([
+        ...(base.disabled_mcps ?? []),
+        ...(override.disabled_mcps ?? []),
+      ]),
+    ],
+    // ... other arrays
+  }
+}
+```
+
+## Extending the Schema
+
+### Adding a New Config Section
+
+1. **Define the Schema**
+
+```typescript
+// src/config/schema.ts
+
+// 1. Create the section schema
+export const MyFeatureConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  setting_a: z.string().optional(),
+  setting_b: z.number().min(0).max(100).optional(),
+  nested: z.object({
+    option_x: z.boolean().default(true),
+    option_y: z.array(z.string()).optional(),
+  }).optional(),
+})
+
+// 2. Export the type
+export type MyFeatureConfig = z.infer<typeof MyFeatureConfigSchema>
+
+// 3. Add to root schema
+export const OhMyOpenCodeConfigSchema = z.object({
+  // ... existing fields
+  my_feature: MyFeatureConfigSchema.optional(),
+})
+```
+
+2. **Regenerate JSON Schema**
+
+```bash
+bun run build:schema
+```
+
+This generates `schema.json` for IDE autocompletion.
+
+3. **Use in Code**
+
+```typescript
+import { loadPluginConfig } from "./plugin-config"
+
+const config = loadPluginConfig(process.cwd(), ctx)
+
+if (config.my_feature?.enabled) {
+  const settingA = config.my_feature.setting_a ?? "default"
+  // Use configuration...
+}
+```
+
+### Adding a New Agent Override Field
+
+```typescript
+// src/config/schema.ts
+
+// 1. Add to AgentOverrideConfigSchema
+export const AgentOverrideConfigSchema = z.object({
+  // ... existing fields
+  my_new_field: z.string().optional(),
+})
+
+// 2. Type is automatically updated
+export type AgentOverrideConfig = z.infer<typeof AgentOverrideConfigSchema>
+```
+
+### Adding a New Disable List
+
+```typescript
+// 1. Define the enum
+export const MyFeatureNameSchema = z.enum([
+  "feature-a",
+  "feature-b",
+  "feature-c",
+])
+
+// 2. Add to root schema
+export const OhMyOpenCodeConfigSchema = z.object({
+  // ... existing fields
+  disabled_my_features: z.array(MyFeatureNameSchema).optional(),
+})
+
+// 3. Handle in merge logic (plugin-config.ts)
+disabled_my_features: [
+  ...new Set([
+    ...(base.disabled_my_features ?? []),
+    ...(override.disabled_my_features ?? []),
+  ]),
+],
+```
+
+## Best Practices
+
+### Schema Design
+
+1. **Use optionals liberally**: All config should work with empty object `{}`
+2. **Provide sensible defaults**: Use `.default()` or handle in code
+3. **Validate ranges**: Use `.min()`, `.max()`, `.regex()` for constraints
+4. **Document with descriptions**: Add comments in schema file
+
+### Config File Organization
+
+1. **User config for personal preferences**: Editor settings, API keys
+2. **Project config for team standards**: Hooks, categories, agent overrides
+3. **Keep secrets out**: Use environment variables via `${VAR}`
+
+### Validation
+
+1. **Check validation errors**: `safeParse()` returns errors, don't ignore
+2. **Log meaningful messages**: Include file path and specific validation issues
+3. **Graceful fallback**: Invalid config shouldn't crash the plugin
+
+## File Reference
+
+| File | Purpose |
+|------|---------|
+| `src/config/schema.ts` | Zod schema definitions (445 lines) |
+| `src/config/index.ts` | Public exports |
+| `src/plugin-config.ts` | Config loading and merging |
+| `src/shared/jsonc-parser.ts` | JSONC parsing utilities |
+| `src/shared/deep-merge.ts` | Recursive object merging |
+| `script/build-schema.ts` | JSON Schema generation |
+
+## Next Steps
+
+- [07-mcp-integration.md](./07-mcp-integration.md) - Understand MCP integration

--- a/docs/developer-guide/07-mcp-integration.md
+++ b/docs/developer-guide/07-mcp-integration.md
@@ -1,0 +1,524 @@
+# MCP Integration
+
+The MCP (Model Context Protocol) system in oh-my-opencode provides a three-tier architecture for integrating external tools and services. MCPs enable agents to access web search, documentation lookup, code search, and custom capabilities through a unified protocol.
+
+## Overview
+
+### Three-Tier MCP System
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                   MCP Integration Layers                     │
+├─────────────────────────────────────────────────────────────┤
+│                                                               │
+│  TIER 1: Built-in MCPs (Remote HTTP)                         │
+│  ┌─────────────────────────────────────────────────────────┐ │
+│  │ websearch (Exa/Tavily) | context7 | grep_app            │ │
+│  │ Location: src/mcp/                                      │ │
+│  │ Transport: Remote HTTP (SSE/Streamable)                 │ │
+│  └─────────────────────────────────────────────────────────┘ │
+│                                                               │
+│  TIER 2: Claude Code Compatible MCPs                         │
+│  ┌─────────────────────────────────────────────────────────┐ │
+│  │ User: ~/.claude/.mcp.json                               │ │
+│  │ Project: .mcp.json, .claude/.mcp.json                   │ │
+│  │ Transport: stdio (local) or HTTP (remote)               │ │
+│  │ Features: ${VAR} env expansion, OAuth support           │ │
+│  └─────────────────────────────────────────────────────────┘ │
+│                                                               │
+│  TIER 3: Skill-Embedded MCPs                                 │
+│  ┌─────────────────────────────────────────────────────────┐ │
+│  │ Defined in: SKILL.md YAML frontmatter or mcp.json       │ │
+│  │ Loaded by: SkillMcpManager                              │ │
+│  │ Lifecycle: Lazy init, 5-minute idle cleanup             │ │
+│  └─────────────────────────────────────────────────────────┘ │
+│                                                               │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### MCP Transport Types
+
+| Transport | Protocol | Use Case | Example |
+|-----------|----------|----------|---------|
+| **Remote HTTP** | SSE/Streamable HTTP | Cloud services, APIs | Exa, Context7 |
+| **stdio** | stdin/stdout | Local processes | Playwright MCP, custom CLIs |
+
+## Built-in MCPs (Tier 1)
+
+Built-in MCPs are remote HTTP services bundled with oh-my-opencode. They require no configuration and work out of the box.
+
+### Available Built-in MCPs
+
+| Name | URL | Purpose | Auth |
+|------|-----|---------|------|
+| `websearch` | mcp.exa.ai / mcp.tavily.com | Real-time web search | Optional (EXA_API_KEY / TAVILY_API_KEY) |
+| `context7` | mcp.context7.com/mcp | Library documentation | Optional (CONTEXT7_API_KEY) |
+| `grep_app` | mcp.grep.app | GitHub code search | None |
+
+### Websearch Configuration
+
+The websearch MCP supports multiple providers:
+
+```jsonc
+// oh-my-opencode.jsonc
+{
+  "websearch": {
+    "provider": "exa"  // or "tavily"
+  }
+}
+```
+
+| Provider | Auth | API Key Required | Notes |
+|----------|------|------------------|-------|
+| `exa` (default) | x-api-key header | No | Works without key, better with key |
+| `tavily` | Bearer token | Yes | Requires TAVILY_API_KEY |
+
+### Disabling Built-in MCPs
+
+```jsonc
+{
+  "disabled_mcps": ["websearch", "grep_app"]
+}
+```
+
+### Adding a New Built-in MCP
+
+1. **Create the MCP config file**
+
+```typescript
+// src/mcp/my-service.ts
+type RemoteMcpConfig = {
+  type: "remote"
+  url: string
+  enabled: boolean
+  headers?: Record<string, string>
+  oauth?: false
+}
+
+export const my_service: RemoteMcpConfig = {
+  type: "remote" as const,
+  url: "https://mcp.myservice.com/mcp",
+  enabled: true,
+  headers: process.env.MY_SERVICE_API_KEY
+    ? { "x-api-key": process.env.MY_SERVICE_API_KEY }
+    : undefined,
+  oauth: false as const,
+}
+```
+
+2. **Register in index.ts**
+
+```typescript
+// src/mcp/index.ts
+import { my_service } from "./my-service"
+
+export function createBuiltinMcps(disabledMcps: string[] = [], config?: OhMyOpenCodeConfig) {
+  const mcps: Record<string, RemoteMcpConfig> = {}
+
+  // ... existing MCPs
+
+  if (!disabledMcps.includes("my_service")) {
+    mcps.my_service = my_service
+  }
+
+  return mcps
+}
+```
+
+3. **Add to schema**
+
+```typescript
+// src/mcp/types.ts
+export const McpNameSchema = z.enum([
+  "websearch",
+  "context7",
+  "grep_app",
+  "my_service",  // Add here
+])
+```
+
+## Claude Code Compatible MCPs (Tier 2)
+
+MCPs defined in `.mcp.json` files are automatically loaded, providing compatibility with Claude Code's MCP system.
+
+### File Locations (Priority Order)
+
+```
+1. .claude/.mcp.json     (project-local, highest priority)
+2. .mcp.json             (project root)
+3. ~/.claude/.mcp.json   (user-level)
+```
+
+### Config Format
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@my-org/my-mcp@latest"],
+      "env": {
+        "API_KEY": "${MY_API_KEY}"
+      }
+    },
+    "remote-server": {
+      "type": "http",
+      "url": "https://mcp.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${API_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+### Environment Variable Expansion
+
+The `${VAR}` syntax expands environment variables:
+
+```json
+{
+  "mcpServers": {
+    "my-mcp": {
+      "command": "npx",
+      "args": ["-y", "@my-org/mcp@latest"],
+      "env": {
+        "API_KEY": "${MY_API_KEY}",          // Expands to process.env.MY_API_KEY
+        "BASE_URL": "${BASE_URL:-default}"   // With default value
+      }
+    }
+  }
+}
+```
+
+### Server Configuration Options
+
+```typescript
+interface ClaudeCodeMcpServer {
+  // Transport type (inferred from url/command if not specified)
+  type?: "http" | "sse" | "stdio"
+  
+  // For HTTP/SSE transport
+  url?: string
+  headers?: Record<string, string>
+  
+  // For stdio transport
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  
+  // OAuth configuration
+  oauth?: {
+    clientId?: string
+    scopes?: string[]
+  }
+  
+  // Disable this server
+  disabled?: boolean
+}
+```
+
+### Disabling via Config
+
+To disable an MCP defined in a parent config:
+
+```json
+{
+  "mcpServers": {
+    "unwanted-mcp": {
+      "disabled": true
+    }
+  }
+}
+```
+
+## Skill-Embedded MCPs (Tier 3)
+
+Skills can include MCP configurations that are loaded on-demand when the skill is activated.
+
+### Defining in SKILL.md
+
+```yaml
+---
+name: my-skill
+description: "Skill with embedded MCP"
+mcp:
+  my-mcp-server:
+    command: npx
+    args:
+      - "@my-org/my-mcp@latest"
+    env:
+      API_KEY: "${MY_API_KEY}"
+---
+
+# My Skill
+
+This skill uses the my-mcp-server MCP...
+```
+
+### Defining in mcp.json
+
+Create `mcp.json` in the skill directory (takes precedence over frontmatter):
+
+```json
+{
+  "mcpServers": {
+    "my-mcp-server": {
+      "command": "npx",
+      "args": ["@my-org/my-mcp@latest"],
+      "env": {
+        "API_KEY": "${MY_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+### SkillMcpManager Lifecycle
+
+The `SkillMcpManager` handles skill MCP lifecycle:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                 Skill MCP Lifecycle                          │
+├─────────────────────────────────────────────────────────────┤
+│                                                               │
+│  1. DISCOVERY                                                 │
+│     - Skill loaded → MCP config extracted                    │
+│     - Config validated (url or command required)             │
+│                                                               │
+│  2. LAZY INITIALIZATION                                       │
+│     - Client NOT created until first tool call               │
+│     - Connection type inferred (http or stdio)               │
+│     - Environment variables expanded                          │
+│                                                               │
+│  3. CONNECTION                                                │
+│     - Stdio: Spawn process, connect via stdin/stdout         │
+│     - HTTP: Connect via StreamableHTTPClientTransport        │
+│     - OAuth flow triggered if configured                     │
+│                                                               │
+│  4. USAGE                                                     │
+│     - Tools/resources accessed via skill_mcp tool            │
+│     - lastUsedAt timestamp updated on each call              │
+│                                                               │
+│  5. CLEANUP                                                   │
+│     - Idle timeout: 5 minutes                                │
+│     - Signal handlers: SIGINT, SIGTERM, SIGBREAK             │
+│     - Session cleanup: All clients for session closed        │
+│                                                               │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Using Skill MCPs
+
+The `skill_mcp` tool invokes skill-embedded MCPs:
+
+```typescript
+// Tool call
+skill_mcp({
+  mcp_name: "my-mcp-server",
+  tool_name: "my_tool",
+  arguments: { param: "value" }
+})
+
+// Or for resources
+skill_mcp({
+  mcp_name: "my-mcp-server",
+  resource_name: "my_resource"
+})
+
+// Or for prompts
+skill_mcp({
+  mcp_name: "my-mcp-server",
+  prompt_name: "my_prompt",
+  arguments: { arg: "value" }
+})
+```
+
+## MCP Loader Implementation
+
+### Claude Code MCP Loader
+
+```typescript
+// src/features/claude-code-mcp-loader/loader.ts
+
+interface McpConfigPath {
+  path: string
+  scope: McpScope  // "user" | "project" | "local"
+}
+
+function getMcpConfigPaths(): McpConfigPath[] {
+  return [
+    { path: join(getClaudeConfigDir(), ".mcp.json"), scope: "user" },
+    { path: join(process.cwd(), ".mcp.json"), scope: "project" },
+    { path: join(process.cwd(), ".claude", ".mcp.json"), scope: "local" },
+  ]
+}
+
+export async function loadMcpConfigs(): Promise<McpLoadResult> {
+  const servers: Record<string, McpServerConfig> = {}
+  const loadedServers: LoadedMcpServer[] = []
+  
+  for (const { path, scope } of getMcpConfigPaths()) {
+    const config = await loadMcpConfigFile(path)
+    if (!config?.mcpServers) continue
+
+    for (const [name, serverConfig] of Object.entries(config.mcpServers)) {
+      // Handle disabled servers
+      if (serverConfig.disabled) {
+        delete servers[name]
+        continue
+      }
+
+      // Transform and store
+      const transformed = transformMcpServer(name, serverConfig)
+      servers[name] = transformed
+      loadedServers.push({ name, scope, config: transformed })
+    }
+  }
+
+  return { servers, loadedServers }
+}
+```
+
+### MCP Server Transformation
+
+```typescript
+// src/features/claude-code-mcp-loader/transformer.ts
+
+export function transformMcpServer(
+  name: string,
+  config: ClaudeCodeMcpServer
+): McpServerConfig {
+  // Expand environment variables
+  const expanded = expandEnvVarsInObject(config)
+
+  // Determine transport type
+  if (expanded.url) {
+    return {
+      type: "remote",
+      url: expanded.url,
+      headers: expanded.headers,
+      enabled: true,
+    }
+  }
+
+  if (expanded.command) {
+    return {
+      type: "local",
+      command: [expanded.command, ...(expanded.args || [])],
+      environment: expanded.env,
+      enabled: true,
+    }
+  }
+
+  throw new Error(`Invalid MCP config for "${name}": missing url or command`)
+}
+```
+
+## Connection Types
+
+### HTTP Transport (Remote MCPs)
+
+For remote MCP servers using HTTP/SSE:
+
+```typescript
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+
+const transport = new StreamableHTTPClientTransport(
+  new URL(config.url),
+  {
+    requestInit: {
+      headers: config.headers,
+    },
+  }
+)
+
+const client = new Client({ name: "oh-my-opencode", version: "1.0" })
+await client.connect(transport)
+```
+
+### Stdio Transport (Local MCPs)
+
+For local MCP processes using stdin/stdout:
+
+```typescript
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
+
+const transport = new StdioClientTransport({
+  command: config.command,
+  args: config.args,
+  env: {
+    ...createCleanMcpEnvironment(),
+    ...config.env,
+  },
+})
+
+const client = new Client({ name: "oh-my-opencode", version: "1.0" })
+await client.connect(transport)
+```
+
+## OAuth Support
+
+MCPs can require OAuth authentication:
+
+```json
+{
+  "mcpServers": {
+    "oauth-protected": {
+      "url": "https://mcp.example.com/mcp",
+      "oauth": {
+        "clientId": "your-client-id",
+        "scopes": ["read", "write"]
+      }
+    }
+  }
+}
+```
+
+The `McpOAuthProvider` handles:
+- Token acquisition and refresh
+- Step-up authentication (additional scopes)
+- Token caching per server URL
+
+## Best Practices
+
+### Built-in MCPs
+
+1. **Use remote HTTP**: Built-in MCPs should be stateless services
+2. **Optional auth**: Support both authenticated and unauthenticated use
+3. **Config factory**: Use factory functions for dynamic config (like websearch)
+
+### Claude Code MCPs
+
+1. **Environment variables**: Never hardcode secrets; use `${VAR}` syntax
+2. **Scope appropriately**: User-level for personal tools, project for team tools
+3. **Version lock**: Pin npm packages to avoid breaking changes
+
+### Skill MCPs
+
+1. **Lazy loading**: MCPs only connect when needed
+2. **Clean environment**: Use `createCleanMcpEnvironment()` to prevent leaks
+3. **Error handling**: Provide helpful error messages for missing config
+
+## File Reference
+
+| File | Purpose |
+|------|---------|
+| `src/mcp/index.ts` | Built-in MCP factory |
+| `src/mcp/websearch.ts` | Exa/Tavily websearch config |
+| `src/mcp/context7.ts` | Context7 docs config |
+| `src/mcp/grep-app.ts` | Grep.app code search config |
+| `src/mcp/types.ts` | McpNameSchema |
+| `src/features/claude-code-mcp-loader/loader.ts` | .mcp.json loading |
+| `src/features/claude-code-mcp-loader/transformer.ts` | Config transformation |
+| `src/features/claude-code-mcp-loader/env-expander.ts` | ${VAR} expansion |
+| `src/features/claude-code-mcp-loader/types.ts` | MCP types |
+| `src/features/skill-mcp-manager/manager.ts` | Skill MCP lifecycle (617 lines) |
+| `src/features/skill-mcp-manager/types.ts` | Skill MCP types |
+| `src/features/mcp-oauth/provider.ts` | OAuth handling |
+
+## Next Steps
+
+- Return to [README.md](./README.md) for the guide index

--- a/docs/developer-guide/README.md
+++ b/docs/developer-guide/README.md
@@ -1,0 +1,201 @@
+# Oh-My-OpenCode Developer Guide
+
+This guide is for developers who want to fork, customize, or contribute to oh-my-opencode. It covers the architecture, extension points, and patterns used throughout the codebase.
+
+## Who This Guide Is For
+
+- **Plugin developers** extending oh-my-opencode functionality
+- **Fork maintainers** customizing for specific use cases
+- **Contributors** adding new features or fixing bugs
+- **Power users** wanting to understand internals
+
+## Prerequisites
+
+Before diving in, ensure you have:
+
+- **Bun** (package manager and runtime) - [Install Bun](https://bun.sh)
+- **Node.js 18+** (for compatibility)
+- **Basic TypeScript knowledge**
+- **Familiarity with Claude Code / OpenCode concepts**
+
+## Quick Start by Task
+
+| I want to... | Start here |
+|--------------|------------|
+| Understand the codebase | [00-architecture-overview.md](./00-architecture-overview.md) |
+| Add a new AI agent | [01-agent-system.md](./01-agent-system.md) |
+| Create a lifecycle hook | [02-hook-system.md](./02-hook-system.md) |
+| Build a new tool | [03-tool-system.md](./03-tool-system.md) |
+| Customize task delegation | [04-delegation-orchestration.md](./04-delegation-orchestration.md) |
+| Create a skill | [05-skill-system.md](./05-skill-system.md) |
+| Modify configuration | [06-config-system.md](./06-config-system.md) |
+| Add an MCP server | [07-mcp-integration.md](./07-mcp-integration.md) |
+
+## Table of Contents
+
+### Core Architecture
+
+1. **[Architecture Overview](./00-architecture-overview.md)**
+   - Project structure and directories
+   - Core components and their relationships
+   - Data flow and execution lifecycle
+   - Extension points overview
+
+### Extension Systems
+
+2. **[Agent System](./01-agent-system.md)**
+   - Agent types (Primary vs Subagent)
+   - Factory pattern and metadata
+   - Model fallback chains
+   - Tool restrictions
+   - Creating new agents
+
+3. **[Hook System](./02-hook-system.md)**
+   - Hook types (PreToolUse, PostToolUse, UserPromptSubmit, etc.)
+   - Execution order and priority
+   - Response transformation
+   - Creating custom hooks
+
+4. **[Tool System](./03-tool-system.md)**
+   - Direct tools vs factory tools
+   - Tool schema definition
+   - Permission models
+   - Tool categories
+   - Creating new tools
+
+5. **[Delegation & Orchestration](./04-delegation-orchestration.md)**
+   - `delegate_task` categories
+   - Background task management
+   - Session continuity
+   - Parallel execution patterns
+
+### Configuration & Integration
+
+6. **[Skill System](./05-skill-system.md)**
+   - Skill vs Agent vs Tool
+   - SKILL.md format and YAML frontmatter
+   - Loading priority
+   - Skill MCP integration
+   - Creating custom skills
+
+7. **[Config System](./06-config-system.md)**
+   - Zod schema validation
+   - JSONC format support
+   - Multi-level config hierarchy
+   - Extending the schema
+
+8. **[MCP Integration](./07-mcp-integration.md)**
+   - Three-tier MCP architecture
+   - Built-in MCPs (Exa, Context7, Grep.app)
+   - Claude Code compatible MCPs
+   - Skill-embedded MCPs
+   - Adding new MCP servers
+
+## Key Concepts
+
+### Extension Points Summary
+
+| Extension Point | Purpose | Complexity |
+|-----------------|---------|------------|
+| **Skill** | Inject domain expertise | Low |
+| **Config Override** | Customize behavior | Low |
+| **Hook** | Intercept lifecycle events | Medium |
+| **Tool** | Add new capabilities | Medium |
+| **Agent** | Create autonomous workers | Medium-High |
+| **Built-in MCP** | Add remote services | Medium |
+
+### Naming Conventions
+
+| Pattern | Example | Usage |
+|---------|---------|-------|
+| `createXXXHook` | `createTodoContinuationEnforcerHook` | Hook factories |
+| `createXXXTool` | `createDelegateTaskTool` | Tool factories |
+| `createXXXAgent` | `createSisyphusAgent` | Agent factories |
+| kebab-case dirs | `background-agent/`, `skill-mcp-manager/` | Directory names |
+
+### Package Management
+
+| Tool | Usage |
+|------|-------|
+| `bun run` | Execute package.json scripts |
+| `bun build` | Build ESM output |
+| `bunx` | Execute binaries |
+| `bun test` | Run test suite |
+
+**Never use npm or yarn** - Bun exclusively.
+
+## Development Workflow
+
+### Building
+
+```bash
+bun run build        # ESM + declarations + schema
+bun run rebuild      # Clean + build
+bun run typecheck    # Type checking only
+```
+
+### Testing
+
+```bash
+bun test                     # Run all tests
+bun test src/agents          # Run tests in directory
+bun test --watch             # Watch mode
+```
+
+### Common Commands
+
+```bash
+bun run build:schema         # Regenerate JSON schema
+bun run lint                 # Lint code
+bun run format               # Format code
+```
+
+## File Structure Reference
+
+```
+src/
+├── agents/        # AI agent definitions
+├── hooks/         # Lifecycle hooks
+├── tools/         # Tool implementations
+├── features/      # Feature modules
+│   ├── background-agent/      # Async task management
+│   ├── builtin-skills/        # Core skills
+│   ├── builtin-commands/      # Slash commands
+│   ├── opencode-skill-loader/ # Skill discovery
+│   ├── skill-mcp-manager/     # MCP lifecycle
+│   └── claude-code-*/         # Compatibility layers
+├── mcp/           # Built-in MCP servers
+├── config/        # Zod schemas
+├── shared/        # Cross-cutting utilities
+└── index.ts       # Plugin entry point
+```
+
+## Anti-Patterns to Avoid
+
+| Category | Forbidden | Alternative |
+|----------|-----------|-------------|
+| **Package Manager** | npm, yarn | Bun exclusively |
+| **Types** | @types/node | bun-types |
+| **Type Safety** | `as any`, `@ts-ignore` | Proper typing |
+| **Testing** | Delete failing tests | Fix the code |
+| **Agent Calls** | Sequential delegation | Parallel `delegate_task` |
+| **Git** | Interactive mode (-i) | Non-interactive commands |
+
+## Getting Help
+
+- **AGENTS.md files**: Each major directory has a knowledge base
+- **Test files**: `*.test.ts` files demonstrate usage
+- **Source code**: The codebase is the ultimate documentation
+
+## Contributing
+
+1. Read the relevant guide section
+2. Follow existing patterns in the codebase
+3. Write tests (TDD: test first, then implement)
+4. Ensure `bun run typecheck` passes
+5. Ensure `bun test` passes
+6. Create PR targeting `dev` branch (never `master`)
+
+---
+
+*This guide is part of [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode).*


### PR DESCRIPTION
## Summary

Adds comprehensive developer documentation for people who fork oh-my-opencode and want to customize it.

## Documents Added (9 files, ~144KB total)

| File | Description |
|------|-------------|
| `README.md` | Index with ToC, quick start by task |
| `00-architecture-overview.md` | Project structure, core components, data flow |
| `01-agent-system.md` | Agent types, factory pattern, fallback chains |
| `02-hook-system.md` | Hook types, execution order, creating hooks |
| `03-tool-system.md` | Tool patterns, schema definitions |
| `04-delegation-orchestration.md` | delegate_task, BackgroundManager, categories |
| `05-skill-system.md` | Skills, SKILL.md format, skill MCP integration |
| `06-config-system.md` | Zod schema, JSONC support, config hierarchy |
| `07-mcp-integration.md` | Three-tier MCP architecture |

## Coverage

All major extension points are documented:
- Agent System (Primary vs Subagent, metadata, fallback chains)
- Hook System (PreToolUse, PostToolUse, UserPromptSubmit, etc.)
- Tool System (Direct vs Factory, schemas, permissions)
- Delegation & Orchestration (categories, background tasks, session continuity)
- Skill System (SKILL.md format, YAML frontmatter, skill MCPs)
- Config System (Zod validation, multi-level hierarchy)
- MCP Integration (built-in, Claude Code compat, skill-embedded)

## Testing

- Documentation only, no code changes
- All links verified to reference existing code paths